### PR TITLE
Add routing

### DIFF
--- a/commitment/imports/ui/App.tsx
+++ b/commitment/imports/ui/App.tsx
@@ -1,13 +1,15 @@
-import React from 'react';
-import { Hello } from './Hello';
-import { Info } from './Info';
+import React from "react";
+import {BrowserRouter, Routes, Route} from "react-router-dom";
+import ExampleView from "@ui/views/ExampleView/ExampleView";
+import LoginView from "@ui/views/LoginView/LoginView";
 
-export const App = () => (
-  <div className="m-9">
-    <h1 className="text-cyan-700 font-sans text-5xl m-9 text-center font-thin">Welcome to Meteor!</h1>
-    <div className="flex flex-col gap-6">
-      <Hello />
-      <Info />
-    </div>
-  </div>
-);
+export const App = () => {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<ExampleView/>}></Route>
+        <Route path="/login" element={<LoginView/>}></Route>
+      </Routes>
+    </BrowserRouter>
+  )
+}

--- a/commitment/imports/ui/components/widgets/examples/Hello.tsx
+++ b/commitment/imports/ui/components/widgets/examples/Hello.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
-import {Card} from './components/ui/card';
-import {Button} from "/imports/ui/components/ui/button";
+import {Card} from '@ui/components/ui/card';
 import {CardContent} from "@ui/components/ui/card";
+import { Button } from '@ui/components/ui/button';
 
 export const Hello = () => {
   const [counter, setCounter] = useState(0);

--- a/commitment/imports/ui/components/widgets/examples/Info.tsx
+++ b/commitment/imports/ui/components/widgets/examples/Info.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useFind, useSubscribe } from "meteor/react-meteor-data";
-import { LinksCollection, Link } from "../api/links";
+import { LinksCollection, Link } from "/imports/api/links";
 import {Card, CardContent, CardHeader, CardTitle} from "@ui/components/ui/card";
 import {Button} from "@ui/components/ui/button";
 

--- a/commitment/imports/ui/views/ExampleView/ExampleView.tsx
+++ b/commitment/imports/ui/views/ExampleView/ExampleView.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { Hello } from "@ui/components/widgets/examples/Hello";
+import { Info } from "@ui/components/widgets/examples/Info";
+
+const ExampleView = () => (
+  <div className="m-9">
+    <h1 className="text-cyan-700 font-sans text-5xl m-9 text-center font-thin">Welcome to Meteor!</h1>
+    <div className="flex flex-col gap-6">
+      <Hello />
+      <Info />
+    </div>
+  </div>
+);
+
+export default ExampleView;

--- a/commitment/imports/ui/views/LoginView/LoginView.tsx
+++ b/commitment/imports/ui/views/LoginView/LoginView.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+const LoginView = () => (
+  <div className="m-9">
+    <h1 className="text-cyan-700 font-sans text-5xl m-9 text-center font-thin">Login Page!</h1>
+    <div className="flex flex-col gap-6">
+      <p>TODO: Add a login page here!</p>
+    </div>
+  </div>
+);
+
+export default LoginView;

--- a/commitment/package-lock.json
+++ b/commitment/package-lock.json
@@ -12,10 +12,12 @@
         "@tailwindcss/postcss": "^4.1.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "history": "^5.3.0",
         "lucide-react": "^0.501.0",
         "meteor-node-stubs": "^1.2.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-router-dom": "^6.30.0",
         "tailwind-merge": "^3.2.0",
         "tailwindcss-animate": "^1.0.7"
       },
@@ -437,6 +439,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@tailwindcss/node": {
@@ -1366,6 +1377,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.6"
       }
     },
     "node_modules/is-binary-path": {
@@ -3387,6 +3407,38 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.0.tgz",
+      "integrity": "sha512-x30B78HV5tFk8ex0ITwzC9TTZMua4jGyA9IUlH1JLQYQTFyxr/ZxwOJq7evg1JX1qGVUcvhsmQSKdPncQrjTgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom/node_modules/react-router": {
+      "version": "6.30.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.0.tgz",
+      "integrity": "sha512-D3X8FyH9nBcTSHGdEKurK7r8OYE1kKFn3d/CF+CoxbSHkxU7o37+Uh7eAHRXr6k2tSExXYO++07PeXJtA/dEhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
       }
     },
     "node_modules/read-cache": {

--- a/commitment/package.json
+++ b/commitment/package.json
@@ -14,10 +14,12 @@
     "@tailwindcss/postcss": "^4.1.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "history": "^5.3.0",
     "lucide-react": "^0.501.0",
     "meteor-node-stubs": "^1.2.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.30.0",
     "tailwind-merge": "^3.2.0",
     "tailwindcss-animate": "^1.0.7"
   },


### PR DESCRIPTION
# Add Routing
## High-Level Description

Adds react-router-dom@6 for routing

---

## Purpose of the Change

I made this change because we need to be able to make multiple pages in our app.

---

## Implementation Details

I used react-router-dom@6 because react-router-dom@7 is currently broken with meteor. 

---

## Steps to Test (if applicable)

Run the web app, and navigate to `/` and `/login`, to see if the page changes between the two.

---

## Screenshots (if applicable)
![Screenshot 2025-05-07 at 3 15 33 pm](https://github.com/user-attachments/assets/0f5979d3-095d-4674-8451-7c123e1edce5)
![Screenshot 2025-05-07 at 3 15 48 pm](https://github.com/user-attachments/assets/7a0daf1f-0da2-4088-90cc-c6ebbc1244a5)

---

## Linked Issue/Story
No issue.
