### PR TITLE
Scaling Config Form

### DIFF
--- a/commitment/imports/ui/components/metrics-page/MetricsTab.tsx
+++ b/commitment/imports/ui/components/metrics-page/MetricsTab.tsx
@@ -7,7 +7,7 @@ import {
 import React from "react";
 import { OverviewPage } from "./OverviewPage";
 import { MetricsPage } from "./MetricsPage";
-import { ScalingView } from "../scaling/ScalingView";
+import ScalingView from "../scaling/ScalingView";
 
 interface TabData {
   value: string;

--- a/commitment/imports/ui/components/scaling/GradingSheetForm.tsx
+++ b/commitment/imports/ui/components/scaling/GradingSheetForm.tsx
@@ -1,1 +1,5 @@
-import React from "react"
+import React from "react";
+
+export const GradingSheetForm = () => {
+  return <div>GRADING SHEET FORM</div>;
+};

--- a/commitment/imports/ui/components/scaling/ScalingConfigForm.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingConfigForm.tsx
@@ -154,13 +154,13 @@ export function ScalingConfigForm({
                     onChange={(e) => field.onChange(e.target.files?.[0])}
                   />
                 </FormControl>
-                <FormDescription>Only `.py` files accepted.</FormDescription>
+                <FormDescription className="justify-center">Only `.py` files accepted.</FormDescription>
                 <FormMessage />
               </FormItem>
             )}
           />
 
-          <Button type="submit" className="bg-orange-400 hover:bg-orange-500">
+          <Button type="submit" className="bg-git-card-primary hover:bg-git-card-secondary">
             Next
           </Button>
         </form>

--- a/commitment/imports/ui/components/scaling/ScalingConfigForm.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingConfigForm.tsx
@@ -196,12 +196,15 @@ export function ScalingConfigForm({
             )}
           />
 
-          <Button
-            type="submit"
-            className="bg-git-card-primary hover:bg-git-card-secondary"
-          >
-            Next
-          </Button>
+          {/* NEXT BUTTON */}
+          <div className="flex justify-center">
+            <Button
+              type="submit"
+              className="bg-git-int-primary text-git-int-text hover:bg-git-int-primary-hover rounded-full px-8"
+            >
+              Next
+            </Button>
+          </div>
         </form>
       </Form>
     </div>

--- a/commitment/imports/ui/components/scaling/ScalingConfigForm.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingConfigForm.tsx
@@ -56,103 +56,110 @@ export function ScalingConfigForm({
 
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-6">
-        {/* Metrics Checkboxes */}
-        <FormField
-          control={form.control}
-          name="metrics"
-          render={() => (
-            <FormItem>
-              <FormLabel>Select scaling metrics*</FormLabel>
-              <div className="flex flex-wrap gap-4">
-                {metricOptions.map((metric) => (
-                  <FormField
-                    key={metric}
-                    control={form.control}
-                    name="metrics"
-                    render={({ field }) => (
+      <div className="max-w-2xl w-full mx-auto">
+        <div className="text-2xl font-bold mb-4 text-center">
+          Generate Scaling
+        </div>
+        <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-6">
+          {/* Metrics Checkboxes */}
+          <FormField
+            control={form.control}
+            name="metrics"
+            render={() => (
+              <FormItem>
+                <FormLabel>Select scaling metrics*</FormLabel>
+                <div className="flex flex-wrap gap-4">
+                  {metricOptions.map((metric) => (
+                    <FormField
+                      key={metric}
+                      control={form.control}
+                      name="metrics"
+                      render={({ field }) => (
+                        <FormItem
+                          key={metric}
+                          className="flex items-center space-x-2"
+                        >
+                          <FormControl>
+                            <Checkbox
+                              checked={field.value?.includes(metric)}
+                              onCheckedChange={(checked) => {
+                                const value = field.value || [];
+                                return checked
+                                  ? field.onChange([...value, metric])
+                                  : field.onChange(
+                                      value.filter((v) => v !== metric)
+                                    );
+                              }}
+                            />
+                          </FormControl>
+                          <FormLabel className="font-normal">
+                            {metric}
+                          </FormLabel>
+                        </FormItem>
+                      )}
+                    />
+                  ))}
+                </div>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          {/* Method Radios */}
+          <FormField
+            control={form.control}
+            name="method"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Select a scaling method*</FormLabel>
+                <FormControl>
+                  <RadioGroup
+                    onValueChange={field.onChange}
+                    defaultValue={field.value}
+                  >
+                    {methodOptions.map((m) => (
                       <FormItem
-                        key={metric}
-                        className="flex items-center space-x-2"
+                        key={m}
+                        className="flex items-center space-x-2 mt-1"
                       >
                         <FormControl>
-                          <Checkbox
-                            checked={field.value?.includes(metric)}
-                            onCheckedChange={(checked) => {
-                              const value = field.value || [];
-                              return checked
-                                ? field.onChange([...value, metric])
-                                : field.onChange(
-                                    value.filter((v) => v !== metric)
-                                  );
-                            }}
-                          />
+                          <RadioGroupItem value={m} />
                         </FormControl>
-                        <FormLabel className="font-normal">{metric}</FormLabel>
+                        <FormLabel className="font-normal">{m}</FormLabel>
                       </FormItem>
-                    )}
+                    ))}
+                  </RadioGroup>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          {/* File Upload */}
+          <FormField
+            control={form.control}
+            name="customScript"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Different Scale? Upload custom script:</FormLabel>
+                <FormControl>
+                  <Input
+                    type="file"
+                    accept=".py"
+                    onChange={(e) => field.onChange(e.target.files?.[0])}
                   />
-                ))}
-              </div>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+                </FormControl>
+                <FormDescription>Only `.py` files accepted.</FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
 
-        {/* Method Radios */}
-        <FormField
-          control={form.control}
-          name="method"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Select a scaling method*</FormLabel>
-              <FormControl>
-                <RadioGroup
-                  onValueChange={field.onChange}
-                  defaultValue={field.value}
-                >
-                  {methodOptions.map((m) => (
-                    <FormItem
-                      key={m}
-                      className="flex items-center space-x-2 mt-1"
-                    >
-                      <FormControl>
-                        <RadioGroupItem value={m} />
-                      </FormControl>
-                      <FormLabel className="font-normal">{m}</FormLabel>
-                    </FormItem>
-                  ))}
-                </RadioGroup>
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
-        {/* File Upload */}
-        <FormField
-          control={form.control}
-          name="customScript"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Different Scale? Upload custom script:</FormLabel>
-              <FormControl>
-                <Input
-                  type="file"
-                  accept=".py"
-                  onChange={(e) => field.onChange(e.target.files?.[0])}
-                />
-              </FormControl>
-              <FormDescription>Only `.py` files accepted.</FormDescription>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
-        <Button type="submit" className="bg-orange-400 hover:bg-orange-500">
-          Next
-        </Button>
-      </form>
+          <Button type="submit" className="bg-orange-400 hover:bg-orange-500">
+            Next
+          </Button>
+        </form>
+      </div>
     </Form>
   );
 }

--- a/commitment/imports/ui/components/scaling/ScalingConfigForm.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingConfigForm.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 
 import {
   Form,
@@ -12,11 +12,12 @@ import {
 
 import { Checkbox } from "@ui/components/ui/checkbox";
 import { RadioGroup, RadioGroupItem } from "@ui/components/ui/radio-group";
-import { Input } from "@ui/components/ui/input";
 import { Button } from "@ui/components/ui/button";
 import { z } from "zod";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Dropzone, DropzoneContent, DropzoneEmptyState } from '../ui/dropzone';
+
 
 const scalingConfigSchema = z.object({
   metrics: z.array(z.string()).min(1, "Select at least one metric"),
@@ -31,14 +32,22 @@ export function ScalingConfigForm({
 }: {
   onSubmit: (config: ScalingConfig) => void;
 }) {
+  const [script, setScript] = useState<File[] | undefined>();
+
   const form = useForm<ScalingConfig>({
     resolver: zodResolver(scalingConfigSchema),
     defaultValues: {
       metrics: [],
       method: "Percentiles",
-      customScript: null,
+      customScript: script,
     },
   });
+
+  // Handle drop of files in the dropzone
+  const handleDrop = (files: File[]) => {
+    console.log(files);
+    setScript(files);
+  };
 
   const handleSubmit = (data: ScalingConfig) => {
     onSubmit(data);
@@ -117,7 +126,8 @@ export function ScalingConfigForm({
                 <FormLabel className="font-bold justify-center">
                   Select a scaling method
                   <span className="text-red-500">*</span>
-                </FormLabel>                <FormControl>
+                </FormLabel>{" "}
+                <FormControl>
                   <RadioGroup
                     onValueChange={field.onChange}
                     defaultValue={field.value}
@@ -146,21 +156,40 @@ export function ScalingConfigForm({
             name="customScript"
             render={({ field }) => (
               <FormItem>
-                <FormLabel className="font-bold justify-center">Different Scale? Upload a custom script:</FormLabel>
+                <FormLabel className="font-bold justify-center">
+                  Different Scale? Upload a custom script:
+                </FormLabel>
                 <FormControl>
-                  <Input
-                    type="file"
-                    accept=".py"
-                    onChange={(e) => field.onChange(e.target.files?.[0])}
-                  />
+                  <Dropzone
+                    onDrop={handleDrop}
+                    onError={console.error}
+                    src={script}
+                  >
+                    <DropzoneEmptyState>
+                      <div className="flex w-full items-center gap-4 p-8">
+                        <div className="text-left">
+                          <p className="font-medium text-sm">Upload a file</p>
+                          <p className="text-muted-foreground text-xs">
+                            Drag and drop or click to upload
+                          </p>
+                        </div>
+                      </div>
+                    </DropzoneEmptyState>
+                    <DropzoneContent />
+                  </Dropzone>
                 </FormControl>
-                <FormDescription className="justify-center">Only `.py` files accepted.</FormDescription>
+                <FormDescription className="justify-center">
+                  Only `.py` files accepted.
+                </FormDescription>
                 <FormMessage />
               </FormItem>
             )}
           />
 
-          <Button type="submit" className="bg-git-card-primary hover:bg-git-card-secondary">
+          <Button
+            type="submit"
+            className="bg-git-card-primary hover:bg-git-card-secondary"
+          >
             Next
           </Button>
         </form>

--- a/commitment/imports/ui/components/scaling/ScalingConfigForm.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingConfigForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState } from 'react';
 
 import {
   Form,
@@ -7,25 +7,25 @@ import {
   FormLabel,
   FormControl,
   FormMessage,
-} from "@ui/components/ui/form";
-import { UploadIcon } from "lucide-react";
-import { Checkbox } from "@ui/components/ui/checkbox";
-import { RadioGroup, RadioGroupItem } from "@ui/components/ui/radio-group";
-import { Button } from "@ui/components/ui/button";
-import { z } from "zod";
-import { useForm } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { Dropzone, DropzoneContent, DropzoneEmptyState } from "../ui/dropzone";
+} from '@ui/components/ui/form';
+import { UploadIcon } from 'lucide-react';
+import { Checkbox } from '@ui/components/ui/checkbox';
+import { RadioGroup, RadioGroupItem } from '@ui/components/ui/radio-group';
+import { Button } from '@ui/components/ui/button';
+import { z } from 'zod';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Dropzone, DropzoneContent, DropzoneEmptyState } from '../ui/dropzone';
 
 const scalingConfigSchema = z.object({
-  metrics: z.array(z.string()).min(1, "Select at least one metric"),
-  method: z.string().nonempty("Select a method"),
+  metrics: z.array(z.string()).min(1, 'Select at least one metric'),
+  method: z.string().nonempty('Select a method'),
   customScript: z.any().optional(),
 });
 
 type ScalingConfig = z.infer<typeof scalingConfigSchema>;
 
-export function ScalingConfigForm({
+function ScalingConfigForm({
   onSubmit,
 }: {
   onSubmit: (config: ScalingConfig) => void;
@@ -36,7 +36,7 @@ export function ScalingConfigForm({
     resolver: zodResolver(scalingConfigSchema),
     defaultValues: {
       metrics: [],
-      method: "Percentiles",
+      method: 'Percentiles',
     },
   });
 
@@ -51,14 +51,14 @@ export function ScalingConfigForm({
   };
 
   const metricOptions = [
-    "Total No. Commits",
-    "Use AI to filter out commits",
-    "LOC",
-    "LOC per commit",
-    "Commits per day",
+    'Total No. Commits',
+    'Use AI to filter out commits',
+    'LOC',
+    'LOC per commit',
+    'Commits per day',
   ];
 
-  const methodOptions = ["Percentiles", "Mean +/- Std", "Quartiles"];
+  const methodOptions = ['Percentiles', 'Mean +/- Std', 'Quartiles'];
 
   return (
     <div className="max-w-full">
@@ -68,7 +68,7 @@ export function ScalingConfigForm({
         </div>
         <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-6">
 
-          {/* METRICS CHECKBOXES*/}
+          {/* METRICS CHECKBOXES */}
           <FormField
             control={form.control}
             name="metrics"
@@ -97,8 +97,8 @@ export function ScalingConfigForm({
                                 return checked
                                   ? field.onChange([...value, metric])
                                   : field.onChange(
-                                      value.filter((v) => v !== metric)
-                                    );
+                                    value.filter((v) => v !== metric),
+                                  );
                               }}
                             />
                           </FormControl>
@@ -124,7 +124,8 @@ export function ScalingConfigForm({
                 <FormLabel className="font-bold justify-center">
                   Select a scaling method
                   <span className="text-red-500">*</span>
-                </FormLabel>{" "}
+                </FormLabel>
+                {' '}
                 <FormControl>
                   <RadioGroup
                     onValueChange={field.onChange}
@@ -165,7 +166,7 @@ export function ScalingConfigForm({
                     }}
                     onError={console.error}
                     src={script}
-                    accept={{ ".py": [] }}
+                    accept={{ '.py': [] }}
                     maxFiles={1}
                     className="border-2 border-dashed border-muted-foreground rounded-md transition-colors hover:border-primary focus:border-primary"
                   >
@@ -183,7 +184,9 @@ export function ScalingConfigForm({
                             Drag and drop or click to select
                           </p>
                           <p className="text-muted-foreground text-xs">
-                            Accepted: <span className="font-mono">.py</span>
+                            Accepted:
+                            {' '}
+                            <span className="font-mono">.py</span>
                           </p>
                         </div>
                       </div>
@@ -210,3 +213,5 @@ export function ScalingConfigForm({
     </div>
   );
 }
+
+export default ScalingConfigForm;

--- a/commitment/imports/ui/components/scaling/ScalingConfigForm.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingConfigForm.tsx
@@ -34,8 +34,8 @@ export function ScalingConfigForm({
   const form = useForm<ScalingConfig>({
     resolver: zodResolver(scalingConfigSchema),
     defaultValues: {
-      metrics: ["Total No. Commits", "LOC per commit"],
-      method: "Mean +/- Std",
+      metrics: [],
+      method: "Percentiles",
       customScript: null,
     },
   });
@@ -135,7 +135,7 @@ export function ScalingConfigForm({
           name="customScript"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Upload custom script (optional)</FormLabel>
+              <FormLabel>Different Scale? Upload custom script:</FormLabel>
               <FormControl>
                 <Input
                   type="file"

--- a/commitment/imports/ui/components/scaling/ScalingConfigForm.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingConfigForm.tsx
@@ -55,8 +55,8 @@ export function ScalingConfigForm({
   const methodOptions = ["Percentiles", "Mean +/- Std", "Quartiles"];
 
   return (
-    <Form {...form}>
-      <div className="max-w-2xl w-full mx-auto">
+    <div className="max-w-full">
+      <Form {...form}>
         <div className="text-2xl font-bold mb-4 text-center">
           Generate Scaling
         </div>
@@ -67,8 +67,11 @@ export function ScalingConfigForm({
             name="metrics"
             render={() => (
               <FormItem>
-                <FormLabel>Select scaling metrics*</FormLabel>
-                <div className="flex flex-wrap gap-4">
+                <FormLabel className="font-bold justify-center">
+                  Select scaling metrics
+                  <span className="text-red-500">*</span>
+                </FormLabel>
+                <div className="flex flex-col gap-2">
                   {metricOptions.map((metric) => (
                     <FormField
                       key={metric}
@@ -111,8 +114,10 @@ export function ScalingConfigForm({
             name="method"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Select a scaling method*</FormLabel>
-                <FormControl>
+                <FormLabel className="font-bold justify-center">
+                  Select a scaling method
+                  <span className="text-red-500">*</span>
+                </FormLabel>                <FormControl>
                   <RadioGroup
                     onValueChange={field.onChange}
                     defaultValue={field.value}
@@ -141,7 +146,7 @@ export function ScalingConfigForm({
             name="customScript"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Different Scale? Upload custom script:</FormLabel>
+                <FormLabel className="font-bold justify-center">Different Scale? Upload a custom script:</FormLabel>
                 <FormControl>
                   <Input
                     type="file"
@@ -159,7 +164,7 @@ export function ScalingConfigForm({
             Next
           </Button>
         </form>
-      </div>
-    </Form>
+      </Form>
+    </div>
   );
 }

--- a/commitment/imports/ui/components/scaling/ScalingConfigForm.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingConfigForm.tsx
@@ -1,1 +1,143 @@
-import React from "react"
+import React from "react";
+
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+  FormDescription,
+} from "@ui/components/ui/form";
+
+import { Checkbox } from "@ui/components/ui/checkbox";
+import { RadioGroup, RadioGroupItem } from "@ui/components/ui/radio-group";
+import { Input } from "@ui/components/ui/input";
+import { Button } from "@ui/components/ui/button";
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+const scalingConfigSchema = z.object({
+  metrics: z.array(z.string()).min(1, "Select at least one metric"),
+  method: z.string().nonempty("Select a method"),
+  customScript: z.any().optional(),
+});
+
+type ScalingConfig = z.infer<typeof scalingConfigSchema>;
+
+export function ScalingConfigForm({ onSubmit }: { onSubmit: (config: ScalingConfig) => void }) {
+  const form = useForm<ScalingConfig>({
+    resolver: zodResolver(scalingConfigSchema),
+    defaultValues: {
+      metrics: ["Total No. Commits", "LOC per commit"],
+      method: "Mean +/- Std",
+      customScript: null,
+    },
+  });
+
+  const handleSubmit = (data: ScalingConfig) => {
+    onSubmit(data);
+  };
+
+  const metricOptions = [
+    "Total No. Commits",
+    "Use AI to filter out commits",
+    "LOC",
+    "LOC per commit",
+    "Commits per day",
+  ];
+
+  const methodOptions = ["Percentiles", "Mean +/- Std", "Quartiles"];
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-6">
+        {/* Metrics Checkboxes */}
+        <FormField
+          control={form.control}
+          name="metrics"
+          render={() => (
+            <FormItem>
+              <FormLabel>Select scaling metrics*</FormLabel>
+              <div className="flex flex-wrap gap-4">
+                {metricOptions.map((metric) => (
+                  <FormField
+                    key={metric}
+                    control={form.control}
+                    name="metrics"
+                    render={({ field }) => (
+                      <FormItem key={metric} className="flex items-center space-x-2">
+                        <FormControl>
+                          <Checkbox
+                            checked={field.value?.includes(metric)}
+                            onCheckedChange={(checked) => {
+                              const value = field.value || [];
+                              return checked
+                                ? field.onChange([...value, metric])
+                                : field.onChange(value.filter((v) => v !== metric));
+                            }}
+                          />
+                        </FormControl>
+                        <FormLabel className="font-normal">{metric}</FormLabel>
+                      </FormItem>
+                    )}
+                  />
+                ))}
+              </div>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Method Radios */}
+        <FormField
+          control={form.control}
+          name="method"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Select a scaling method*</FormLabel>
+              <FormControl>
+                <RadioGroup onValueChange={field.onChange} defaultValue={field.value}>
+                  {methodOptions.map((m) => (
+                    <FormItem key={m} className="flex items-center space-x-2 mt-1">
+                      <FormControl>
+                        <RadioGroupItem value={m} />
+                      </FormControl>
+                      <FormLabel className="font-normal">{m}</FormLabel>
+                    </FormItem>
+                  ))}
+                </RadioGroup>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* File Upload */}
+        <FormField
+          control={form.control}
+          name="customScript"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Upload custom script (optional)</FormLabel>
+              <FormControl>
+                <Input
+                  type="file"
+                  accept=".py"
+                  onChange={(e) => field.onChange(e.target.files?.[0])}
+                />
+              </FormControl>
+              <FormDescription>Only `.py` files accepted.</FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <Button type="submit" className="bg-orange-400 hover:bg-orange-500">
+          Next
+        </Button>
+      </form>
+    </Form>
+  );
+}

--- a/commitment/imports/ui/components/scaling/ScalingConfigForm.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingConfigForm.tsx
@@ -37,7 +37,6 @@ export function ScalingConfigForm({
     defaultValues: {
       metrics: [],
       method: "Percentiles",
-      customScript: script,
     },
   });
 
@@ -68,7 +67,8 @@ export function ScalingConfigForm({
           Generate Scaling
         </div>
         <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-6">
-          {/* Metrics Checkboxes */}
+
+          {/* METRICS CHECKBOXES*/}
           <FormField
             control={form.control}
             name="metrics"
@@ -115,7 +115,7 @@ export function ScalingConfigForm({
             )}
           />
 
-          {/* Method Radios */}
+          {/* METHOD RADIO BUTTONS */}
           <FormField
             control={form.control}
             name="method"
@@ -148,7 +148,7 @@ export function ScalingConfigForm({
             )}
           />
 
-          {/* File Upload */}
+          {/* FILE UPLOAD */}
           <FormField
             control={form.control}
             name="customScript"

--- a/commitment/imports/ui/components/scaling/ScalingConfigForm.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingConfigForm.tsx
@@ -7,17 +7,15 @@ import {
   FormLabel,
   FormControl,
   FormMessage,
-  FormDescription,
 } from "@ui/components/ui/form";
-
+import { UploadIcon } from "lucide-react";
 import { Checkbox } from "@ui/components/ui/checkbox";
 import { RadioGroup, RadioGroupItem } from "@ui/components/ui/radio-group";
 import { Button } from "@ui/components/ui/button";
 import { z } from "zod";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Dropzone, DropzoneContent, DropzoneEmptyState } from '../ui/dropzone';
-
+import { Dropzone, DropzoneContent, DropzoneEmptyState } from "../ui/dropzone";
 
 const scalingConfigSchema = z.object({
   metrics: z.array(z.string()).min(1, "Select at least one metric"),
@@ -157,20 +155,35 @@ export function ScalingConfigForm({
             render={({ field }) => (
               <FormItem>
                 <FormLabel className="font-bold justify-center">
-                  Different Scale? Upload a custom script:
+                  Custom scaling? Upload a Python script:
                 </FormLabel>
                 <FormControl>
                   <Dropzone
-                    onDrop={handleDrop}
+                    onDrop={(files) => {
+                      handleDrop(files);
+                      field.onChange(files);
+                    }}
                     onError={console.error}
                     src={script}
+                    accept={{ ".py": [] }}
+                    maxFiles={1}
+                    className="border-2 border-dashed border-muted-foreground rounded-md transition-colors hover:border-primary focus:border-primary"
                   >
                     <DropzoneEmptyState>
-                      <div className="flex w-full items-center gap-4 p-8">
-                        <div className="text-left">
-                          <p className="font-medium text-sm">Upload a file</p>
+                      <div className="flex flex-col items-center w-full py-4">
+                        <UploadIcon
+                          size={32}
+                          className="mb-2 text-muted-foreground"
+                        />
+                        <div className="text-center w-full">
+                          <p className="font-medium text-sm mb-1">
+                            Upload a Python file
+                          </p>
+                          <p className="text-muted-foreground text-xs mb-0.5">
+                            Drag and drop or click to select
+                          </p>
                           <p className="text-muted-foreground text-xs">
-                            Drag and drop or click to upload
+                            Accepted: <span className="font-mono">.py</span>
                           </p>
                         </div>
                       </div>
@@ -178,9 +191,6 @@ export function ScalingConfigForm({
                     <DropzoneContent />
                   </Dropzone>
                 </FormControl>
-                <FormDescription className="justify-center">
-                  Only `.py` files accepted.
-                </FormDescription>
                 <FormMessage />
               </FormItem>
             )}

--- a/commitment/imports/ui/components/scaling/ScalingConfigForm.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingConfigForm.tsx
@@ -26,7 +26,11 @@ const scalingConfigSchema = z.object({
 
 type ScalingConfig = z.infer<typeof scalingConfigSchema>;
 
-export function ScalingConfigForm({ onSubmit }: { onSubmit: (config: ScalingConfig) => void }) {
+export function ScalingConfigForm({
+  onSubmit,
+}: {
+  onSubmit: (config: ScalingConfig) => void;
+}) {
   const form = useForm<ScalingConfig>({
     resolver: zodResolver(scalingConfigSchema),
     defaultValues: {
@@ -67,7 +71,10 @@ export function ScalingConfigForm({ onSubmit }: { onSubmit: (config: ScalingConf
                     control={form.control}
                     name="metrics"
                     render={({ field }) => (
-                      <FormItem key={metric} className="flex items-center space-x-2">
+                      <FormItem
+                        key={metric}
+                        className="flex items-center space-x-2"
+                      >
                         <FormControl>
                           <Checkbox
                             checked={field.value?.includes(metric)}
@@ -75,7 +82,9 @@ export function ScalingConfigForm({ onSubmit }: { onSubmit: (config: ScalingConf
                               const value = field.value || [];
                               return checked
                                 ? field.onChange([...value, metric])
-                                : field.onChange(value.filter((v) => v !== metric));
+                                : field.onChange(
+                                    value.filter((v) => v !== metric)
+                                  );
                             }}
                           />
                         </FormControl>
@@ -98,9 +107,15 @@ export function ScalingConfigForm({ onSubmit }: { onSubmit: (config: ScalingConf
             <FormItem>
               <FormLabel>Select a scaling method*</FormLabel>
               <FormControl>
-                <RadioGroup onValueChange={field.onChange} defaultValue={field.value}>
+                <RadioGroup
+                  onValueChange={field.onChange}
+                  defaultValue={field.value}
+                >
                   {methodOptions.map((m) => (
-                    <FormItem key={m} className="flex items-center space-x-2 mt-1">
+                    <FormItem
+                      key={m}
+                      className="flex items-center space-x-2 mt-1"
+                    >
                       <FormControl>
                         <RadioGroupItem value={m} />
                       </FormControl>

--- a/commitment/imports/ui/components/scaling/ScalingView.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingView.tsx
@@ -1,7 +1,5 @@
-import React from "react";
-
+import React, { useState, useEffect } from "react";
 import { ScalingConfigForm } from "./ScalingConfigForm";
-import { useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -20,11 +18,25 @@ interface ScalingConfig {
 }
 
 export const ScalingView = () => {
-  const [step, setStep] = useState<1 | 2 | 3>(1);
+  // Grab from local storage, defines if visited or not
+  const [visited, setVisited] = useState(false);
 
-  // Shared state
+  // Step of scaling config wizard
+  const [step, setStep] = useState<"config" | "sheet" | "done">("config");
+  const [showDialog, setShowDialog] = useState(false);
+
+  // Shared state for config and grading sheet
   const [config, setConfig] = useState<ScalingConfig | null>(null);
   const [gradingSheet, setGradingSheet] = useState<File | null>(null);
+
+  // Flow for first visits
+  useEffect(() => {
+    // Grab from local storage first
+    const visited = localStorage.getItem("hasVisitedScaling") === "true";
+    setVisited(visited);
+    setShowDialog(!visited); //Opens automatically on first visit
+  }, []);
+
   const handleConfigSubmit = (configData: ScalingConfig) => {
     setConfig(configData);
     setStep(2);

--- a/commitment/imports/ui/components/scaling/ScalingView.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingView.tsx
@@ -66,7 +66,7 @@ export const ScalingView = () => {
 
           {/* MULTI STEP DIALOG */}
           <Dialog open={showDialog} onOpenChange={setShowDialog}>
-            <DialogContent className="max-w-xl">
+            <DialogContent className="max-w-4xl w-full">
               {step === "config" && (
                 <ScalingConfigForm onSubmit={handleConfigSubmit} />
               )}

--- a/commitment/imports/ui/components/scaling/ScalingView.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingView.tsx
@@ -57,6 +57,7 @@ export const ScalingView = () => {
         <div className="max-w-[1600px] mx-20 rounded-2xl bg-white p-8">
           {/* DEFAULT BACKGROUND */}
           <Button
+            className="bg-git-int-primary text-git-int-text hover:bg-git-int-primary-hover"
             onClick={() => {
               setStep("config");
               setShowDialog(true);
@@ -67,7 +68,6 @@ export const ScalingView = () => {
 
           {/* MULTI STEP DIALOG */}
           <Dialog open={showDialog} onOpenChange={setShowDialog}>
-
             {/* here to mute any errors */}
             <DialogHeader>
               <DialogTitle />

--- a/commitment/imports/ui/components/scaling/ScalingView.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingView.tsx
@@ -40,6 +40,7 @@ export const ScalingView = () => {
 
   const handleConfigSubmit = (configData: ScalingConfig) => {
     setConfig(configData);
+    console.log("Config submitted:", configData);
     setStep("sheet");
   };
 
@@ -66,6 +67,12 @@ export const ScalingView = () => {
 
           {/* MULTI STEP DIALOG */}
           <Dialog open={showDialog} onOpenChange={setShowDialog}>
+
+            {/* here to mute any errors */}
+            <DialogHeader>
+              <DialogTitle />
+              <DialogDescription />
+            </DialogHeader>
             <DialogContent className="max-w-full">
               {step === "config" && (
                 <ScalingConfigForm onSubmit={handleConfigSubmit} />

--- a/commitment/imports/ui/components/scaling/ScalingView.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingView.tsx
@@ -46,7 +46,7 @@ export const ScalingView = () => {
   const handleSheetSubmit = (sheetFile: File) => {
     setGradingSheet(sheetFile);
     setStep("done");
-    setVisited(true);
+    setCompleted(true);
     setShowDialog(false);
   };
 
@@ -54,16 +54,15 @@ export const ScalingView = () => {
     <div className="m-0 scroll-smooth">
       <div className="flex flex-col gap-32">
         <div className="max-w-[1600px] mx-20 rounded-2xl bg-white p-8">
-
           {/* DEFAULT BACKGROUND */}
-            <Button
-              onClick={() => {
-                setStep("config");
-                setShowDialog(true);
-              }}
-            >
-              Create New Scaling
-            </Button>
+          <Button
+            onClick={() => {
+              setStep("config");
+              setShowDialog(true);
+            }}
+          >
+            Create New Scaling
+          </Button>
 
           {/* MULTI STEP DIALOG */}
           <Dialog open={showDialog} onOpenChange={setShowDialog}>

--- a/commitment/imports/ui/components/scaling/ScalingView.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingView.tsx
@@ -32,14 +32,21 @@ export const ScalingView = () => {
   // Flow for first visits
   useEffect(() => {
     // Grab from local storage first
-    const visited = localStorage.getItem("hasVisitedScaling") === "true";
-    setVisited(visited);
+    const lsVisited = localStorage.getItem("hasVisitedScaling") === "true";
+    setVisited(lsVisited);
     setShowDialog(!visited); //Opens automatically on first visit
   }, []);
 
   const handleConfigSubmit = (configData: ScalingConfig) => {
     setConfig(configData);
-    setStep(2);
+    setStep("sheet");
+  };
+
+  const handleSheetSubmit = (sheetFile: File) => {
+    setGradingSheet(sheetFile);
+    setStep("done");
+    setVisited(true);
+    setShowDialog(false)
   };
 
   return (

--- a/commitment/imports/ui/components/scaling/ScalingView.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingView.tsx
@@ -46,27 +46,20 @@ export const ScalingView = () => {
     setGradingSheet(sheetFile);
     setStep("done");
     setVisited(true);
-    setShowDialog(false)
+    setShowDialog(false);
   };
 
   return (
     <div className="m-0 scroll-smooth">
       <div className="flex flex-col gap-32">
         <div className="max-w-[1600px] mx-20 rounded-2xl bg-white p-8">
-          {/* TRIGGER FOR SCALING WIZARD */}
-          <Dialog>
-            <DialogTrigger asChild>
-              <Button className="bg-orange-400"> Generate New Scaling</Button>
-            </DialogTrigger>
-            <DialogContent>
-              <DialogHeader>
-                <DialogTitle>Scaling Configuration</DialogTitle>
-              </DialogHeader>
-              <ScalingConfigForm
-                onSubmit={(data) => {
-                  console.log("Submitted Config", data);
-                }}
-              />
+          {/* MULTI STEP DIALOG */}
+          <Dialog open={showDialog} onOpenChange={setShowDialog}>
+            <DialogContent className="max-w-xl">
+              {step === "config" && (
+                <ScalingConfigForm onSubmit={handleConfigSubmit} />
+              )}
+              {/* ADD STEP FOR GRADING SHEET FORM */}
             </DialogContent>
           </Dialog>
         </div>

--- a/commitment/imports/ui/components/scaling/ScalingView.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingView.tsx
@@ -15,7 +15,7 @@ import { GradingSheetForm } from "./GradingSheetForm";
 interface ScalingConfig {
   metrics: string[];
   method: string;
-  customScript?: File;
+  customScript?: File[];
 }
 
 export const ScalingView = () => {

--- a/commitment/imports/ui/components/scaling/ScalingView.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingView.tsx
@@ -10,6 +10,7 @@ import {
 } from "../ui/dialog";
 
 import { Button } from "../ui/button";
+import { GradingSheetForm } from "./GradingSheetForm";
 
 interface ScalingConfig {
   metrics: string[];
@@ -18,8 +19,8 @@ interface ScalingConfig {
 }
 
 export const ScalingView = () => {
-  // Grab from local storage, defines if visited or not
-  const [visited, setVisited] = useState(false);
+  // Grab from local storage, defines if completed or not
+  const [completed, setCompleted] = useState(false);
 
   // Step of scaling config wizard
   const [step, setStep] = useState<"config" | "sheet" | "done">("config");
@@ -32,9 +33,9 @@ export const ScalingView = () => {
   // Flow for first visits
   useEffect(() => {
     // Grab from local storage first
-    const lsVisited = localStorage.getItem("hasVisitedScaling") === "true";
-    setVisited(lsVisited);
-    setShowDialog(!visited); //Opens automatically on first visit
+    const lsCompleted = localStorage.getItem("hasVisitedScaling") === "true";
+    setCompleted(lsCompleted);
+    setShowDialog(!completed); //Opens automatically if we haven't made scaling yet
   }, []);
 
   const handleConfigSubmit = (configData: ScalingConfig) => {
@@ -53,13 +54,24 @@ export const ScalingView = () => {
     <div className="m-0 scroll-smooth">
       <div className="flex flex-col gap-32">
         <div className="max-w-[1600px] mx-20 rounded-2xl bg-white p-8">
+
+          {/* DEFAULT BACKGROUND */}
+            <Button
+              onClick={() => {
+                setStep("config");
+                setShowDialog(true);
+              }}
+            >
+              Create New Scaling
+            </Button>
+
           {/* MULTI STEP DIALOG */}
           <Dialog open={showDialog} onOpenChange={setShowDialog}>
             <DialogContent className="max-w-xl">
               {step === "config" && (
                 <ScalingConfigForm onSubmit={handleConfigSubmit} />
               )}
-              {/* ADD STEP FOR GRADING SHEET FORM */}
+              {step === "sheet" && <GradingSheetForm />}
             </DialogContent>
           </Dialog>
         </div>

--- a/commitment/imports/ui/components/scaling/ScalingView.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingView.tsx
@@ -1,10 +1,29 @@
+import React from "react";
 
+import { ScalingConfigForm } from "./ScalingConfigForm";
+import { useState } from "react";
+
+interface ScalingConfig {
+  metrics: string[];
+  method: string;
+  customScript?: File;
+}
 
 export const ScalingView = () => {
 
+    const [step, setStep] = useState<1 | 2 | 3>(1);
+
+  // Shared state
+  const [config, setConfig] = useState<ScalingConfig | null>(null);
+  const [gradingSheet, setGradingSheet] = useState<File | null>(null);
+  const handleConfigSubmit = (configData: ScalingConfig) => {
+    setConfig(configData);
+    setStep(2);
+  };
+
     return(
         <div>
-
+            <ScalingConfigForm onSubmit={handleConfigSubmit}/>
         </div>
     );
 }

--- a/commitment/imports/ui/components/scaling/ScalingView.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingView.tsx
@@ -66,7 +66,7 @@ export const ScalingView = () => {
 
           {/* MULTI STEP DIALOG */}
           <Dialog open={showDialog} onOpenChange={setShowDialog}>
-            <DialogContent className="max-w-4xl w-full">
+            <DialogContent className="max-w-full">
               {step === "config" && (
                 <ScalingConfigForm onSubmit={handleConfigSubmit} />
               )}

--- a/commitment/imports/ui/components/scaling/ScalingView.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingView.tsx
@@ -2,6 +2,16 @@ import React from "react";
 
 import { ScalingConfigForm } from "./ScalingConfigForm";
 import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "../ui/dialog";
+
+import { Button } from "../ui/button";
 
 interface ScalingConfig {
   metrics: string[];
@@ -10,8 +20,7 @@ interface ScalingConfig {
 }
 
 export const ScalingView = () => {
-
-    const [step, setStep] = useState<1 | 2 | 3>(1);
+  const [step, setStep] = useState<1 | 2 | 3>(1);
 
   // Shared state
   const [config, setConfig] = useState<ScalingConfig | null>(null);
@@ -21,9 +30,28 @@ export const ScalingView = () => {
     setStep(2);
   };
 
-    return(
-        <div>
-            <ScalingConfigForm onSubmit={handleConfigSubmit}/>
+  return (
+    <div className="m-0 scroll-smooth">
+      <div className="flex flex-col gap-32">
+        <div className="max-w-[1600px] mx-20 rounded-2xl bg-white p-8">
+          {/* TRIGGER FOR SCALING WIZARD */}
+          <Dialog>
+            <DialogTrigger asChild>
+              <Button className="bg-orange-400"> Generate New Scaling</Button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Scaling Configuration</DialogTitle>
+              </DialogHeader>
+              <ScalingConfigForm
+                onSubmit={(data) => {
+                  console.log("Submitted Config", data);
+                }}
+              />
+            </DialogContent>
+          </Dialog>
         </div>
-    );
-}
+      </div>
+    </div>
+  );
+};

--- a/commitment/imports/ui/components/scaling/ScalingView.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingView.tsx
@@ -1,16 +1,15 @@
-import React, { useState, useEffect } from "react";
-import { ScalingConfigForm } from "./ScalingConfigForm";
+import React, { useState, useEffect } from 'react';
+import ScalingConfigForm from './ScalingConfigForm';
 import {
   Dialog,
   DialogContent,
   DialogDescription,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
-} from "../ui/dialog";
+} from '../ui/dialog';
 
-import { Button } from "../ui/button";
-import { GradingSheetForm } from "./GradingSheetForm";
+import { Button } from '../ui/button';
+import { GradingSheetForm } from './GradingSheetForm';
 
 interface ScalingConfig {
   metrics: string[];
@@ -18,12 +17,12 @@ interface ScalingConfig {
   customScript?: File[];
 }
 
-export const ScalingView = () => {
+function ScalingView() {
   // Grab from local storage, defines if completed or not
   const [completed, setCompleted] = useState(false);
 
   // Step of scaling config wizard
-  const [step, setStep] = useState<"config" | "sheet" | "done">("config");
+  const [step, setStep] = useState<'config' | 'sheet' | 'done'>('config');
   const [showDialog, setShowDialog] = useState(false);
 
   // Shared state for config and grading sheet
@@ -33,20 +32,20 @@ export const ScalingView = () => {
   // Flow for first visits
   useEffect(() => {
     // Grab from local storage first
-    const lsCompleted = localStorage.getItem("hasVisitedScaling") === "true";
+    const lsCompleted = localStorage.getItem('hasVisitedScaling') === 'true';
     setCompleted(lsCompleted);
-    setShowDialog(!completed); //Opens automatically if we haven't made scaling yet
+    setShowDialog(!completed); // Opens automatically if we haven't made scaling yet
   }, []);
 
   const handleConfigSubmit = (configData: ScalingConfig) => {
     setConfig(configData);
-    console.log("Config submitted:", configData);
-    setStep("sheet");
+    console.log('Config submitted:', configData);
+    setStep('sheet');
   };
 
   const handleSheetSubmit = (sheetFile: File) => {
     setGradingSheet(sheetFile);
-    setStep("done");
+    setStep('done');
     setCompleted(true);
     setShowDialog(false);
   };
@@ -59,7 +58,7 @@ export const ScalingView = () => {
           <Button
             className="bg-git-int-primary text-git-int-text hover:bg-git-int-primary-hover"
             onClick={() => {
-              setStep("config");
+              setStep('config');
               setShowDialog(true);
             }}
           >
@@ -74,14 +73,16 @@ export const ScalingView = () => {
               <DialogDescription />
             </DialogHeader>
             <DialogContent className="max-w-full">
-              {step === "config" && (
+              {step === 'config' && (
                 <ScalingConfigForm onSubmit={handleConfigSubmit} />
               )}
-              {step === "sheet" && <GradingSheetForm />}
+              {step === 'sheet' && <GradingSheetForm />}
             </DialogContent>
           </Dialog>
         </div>
       </div>
     </div>
   );
-};
+}
+
+export default ScalingView

--- a/commitment/imports/ui/components/ui/button.tsx
+++ b/commitment/imports/ui/components/ui/button.tsx
@@ -5,26 +5,27 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@ui/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow-sm hover:bg-primary/90",
+          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
         destructive:
-          "bg-destructive text-destructive-foreground shadow-xs hover:bg-destructive/90",
+          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
-          "border border-input bg-background shadow-xs hover:bg-accent hover:text-accent-foreground",
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
         secondary:
           "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
+        ghost:
+          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-9 px-4 py-2",
-        sm: "h-8 rounded-md px-3 text-xs",
-        lg: "h-10 rounded-md px-8",
-        icon: "h-9 w-9",
+        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        icon: "size-9",
       },
     },
     defaultVariants: {
@@ -34,24 +35,25 @@ const buttonVariants = cva(
   }
 )
 
-export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {
-  asChild?: boolean
-}
+function Button({
+  className,
+  variant,
+  size,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean
+  }) {
+  const Comp = asChild ? Slot : "button"
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button"
-    return (
-      <Comp
-        className={cn(buttonVariants({ variant, size, className }))}
-        ref={ref}
-        {...props}
-      />
-    )
-  }
-)
-Button.displayName = "Button"
+  return (
+    <Comp
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
 
 export { Button, buttonVariants }

--- a/commitment/imports/ui/components/ui/dialog.tsx
+++ b/commitment/imports/ui/components/ui/dialog.tsx
@@ -1,0 +1,141 @@
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { XIcon } from "lucide-react"
+
+import { cn } from "@ui/lib/utils"
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/commitment/imports/ui/components/ui/dropzone.tsx
+++ b/commitment/imports/ui/components/ui/dropzone.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import React from 'react';
 import { UploadIcon } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { createContext, useContext } from 'react';

--- a/commitment/imports/ui/components/ui/form.tsx
+++ b/commitment/imports/ui/components/ui/form.tsx
@@ -5,6 +5,7 @@ import {
   Controller,
   FormProvider,
   useFormContext,
+  useFormState,
   type ControllerProps,
   type FieldPath,
   type FieldValues,
@@ -17,7 +18,7 @@ const Form = FormProvider
 
 type FormFieldContextValue<
   TFieldValues extends FieldValues = FieldValues,
-  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
 > = {
   name: TName
 }
@@ -28,7 +29,7 @@ const FormFieldContext = React.createContext<FormFieldContextValue>(
 
 const FormField = <
   TFieldValues extends FieldValues = FieldValues,
-  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
 >({
   ...props
 }: ControllerProps<TFieldValues, TName>) => {
@@ -42,8 +43,8 @@ const FormField = <
 const useFormField = () => {
   const fieldContext = React.useContext(FormFieldContext)
   const itemContext = React.useContext(FormItemContext)
-  const { getFieldState, formState } = useFormContext()
-
+  const { getFieldState } = useFormContext()
+  const formState = useFormState({ name: fieldContext.name })
   const fieldState = getFieldState(fieldContext.name, formState)
 
   if (!fieldContext) {
@@ -70,46 +71,43 @@ const FormItemContext = React.createContext<FormItemContextValue>(
   {} as FormItemContextValue
 )
 
-const FormItem = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => {
+function FormItem({ className, ...props }: React.ComponentProps<"div">) {
   const id = React.useId()
 
   return (
     <FormItemContext.Provider value={{ id }}>
-      <div ref={ref} className={cn("space-y-2", className)} {...props} />
+      <div
+        data-slot="form-item"
+        className={cn("grid gap-2", className)}
+        {...props}
+      />
     </FormItemContext.Provider>
   )
-})
-FormItem.displayName = "FormItem"
+}
 
-const FormLabel = React.forwardRef<
-  React.ElementRef<typeof LabelPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
->(({ className, ...props }, ref) => {
+function FormLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
   const { error, formItemId } = useFormField()
 
   return (
     <Label
-      ref={ref}
-      className={cn(error && "text-destructive", className)}
+      data-slot="form-label"
+      data-error={!!error}
+      className={cn("data-[error=true]:text-destructive", className)}
       htmlFor={formItemId}
       {...props}
     />
   )
-})
-FormLabel.displayName = "FormLabel"
+}
 
-const FormControl = React.forwardRef<
-  React.ElementRef<typeof Slot>,
-  React.ComponentPropsWithoutRef<typeof Slot>
->(({ ...props }, ref) => {
+function FormControl({ ...props }: React.ComponentProps<typeof Slot>) {
   const { error, formItemId, formDescriptionId, formMessageId } = useFormField()
 
   return (
     <Slot
-      ref={ref}
+      data-slot="form-control"
       id={formItemId}
       aria-describedby={
         !error
@@ -120,63 +118,40 @@ const FormControl = React.forwardRef<
       {...props}
     />
   )
-})
-FormControl.displayName = "FormControl"
+}
 
-const FormDescription = React.forwardRef<
-  HTMLParagraphElement,
-  React.HTMLAttributes<HTMLParagraphElement>
->(({ className, ...props }, ref) => {
+function FormDescription({ className, ...props }: React.ComponentProps<"p">) {
   const { formDescriptionId } = useFormField()
 
   return (
     <p
-      ref={ref}
+      data-slot="form-description"
       id={formDescriptionId}
-      className={cn("text-[0.8rem] text-muted-foreground", className)}
+      className={cn("text-muted-foreground text-sm", className)}
       {...props}
     />
   )
-})
-FormDescription.displayName = "FormDescription"
-
-
-interface FormMessageProps extends React.HTMLAttributes<HTMLParagraphElement> {
-  /// When true, the component won't return null when there is no error, but an empty <p/>
-  displayWithoutError?: boolean
-  reduceHeightWithoutError?: boolean
-
-  // Extra class name to use if there is an error
-  errorClassName?: string
-  // Extra class name to use if there is not a class name
-  noErrorClassName?: string
 }
 
-const FormMessage = React.forwardRef<
-  HTMLParagraphElement,
-  FormMessageProps
->(({ className, children, ...props }, ref) => {
+function FormMessage({ className, ...props }: React.ComponentProps<"p">) {
   const { error, formMessageId } = useFormField()
-  const body = error ? String(error?.message ?? "") : children
+  const body = error ? String(error?.message ?? "") : props.children
 
-  if (!props.displayWithoutError && !body) {
+  if (!body) {
     return null
   }
 
-  const extraClassName = (body ? props.errorClassName : props.noErrorClassName) ?? "";
-
   return (
     <p
-      ref={ref}
+      data-slot="form-message"
       id={formMessageId}
-      className={cn(`text-[0.8rem] font-medium text-destructive ${extraClassName}`, className)}
+      className={cn("text-destructive text-sm", className)}
       {...props}
     >
       {body}
     </p>
   )
-})
-FormMessage.displayName = "FormMessage"
+}
 
 export {
   useFormField,

--- a/commitment/imports/ui/components/ui/index.tsx
+++ b/commitment/imports/ui/components/ui/index.tsx
@@ -1,0 +1,202 @@
+'use client';
+
+import { UploadIcon } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { createContext, useContext } from 'react';
+import type { DropEvent, DropzoneOptions, FileRejection } from 'react-dropzone';
+import { useDropzone } from 'react-dropzone';
+import { Button } from './button';
+import { cn } from '../../lib/utils';
+
+type DropzoneContextType = {
+  src?: File[];
+  accept?: DropzoneOptions['accept'];
+  maxSize?: DropzoneOptions['maxSize'];
+  minSize?: DropzoneOptions['minSize'];
+  maxFiles?: DropzoneOptions['maxFiles'];
+};
+
+const renderBytes = (bytes: number) => {
+  const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+  let size = bytes;
+  let unitIndex = 0;
+
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex++;
+  }
+
+  return `${size.toFixed(2)}${units[unitIndex]}`;
+};
+
+const DropzoneContext = createContext<DropzoneContextType | undefined>(
+  undefined
+);
+
+export type DropzoneProps = Omit<DropzoneOptions, 'onDrop'> & {
+  src?: File[];
+  className?: string;
+  onDrop?: (
+    acceptedFiles: File[],
+    fileRejections: FileRejection[],
+    event: DropEvent
+  ) => void;
+  children?: ReactNode;
+};
+
+export const Dropzone = ({
+  accept,
+  maxFiles = 1,
+  maxSize,
+  minSize,
+  onDrop,
+  onError,
+  disabled,
+  src,
+  className,
+  children,
+  ...props
+}: DropzoneProps) => {
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    accept,
+    maxFiles,
+    maxSize,
+    minSize,
+    onError,
+    disabled,
+    onDrop: (acceptedFiles, fileRejections, event) => {
+      if (fileRejections.length > 0) {
+        const message = fileRejections.at(0)?.errors.at(0)?.message;
+        onError?.(new Error(message));
+        return;
+      }
+
+      onDrop?.(acceptedFiles, fileRejections, event);
+    },
+    ...props,
+  });
+
+  return (
+    <DropzoneContext.Provider
+      key={JSON.stringify(src)}
+      value={{ src, accept, maxSize, minSize, maxFiles }}
+    >
+      <Button
+        className={cn(
+          'relative h-auto w-full flex-col overflow-hidden p-8',
+          isDragActive && 'outline-none ring-1 ring-ring',
+          className
+        )}
+        disabled={disabled}
+        type="button"
+        variant="outline"
+        {...getRootProps()}
+      >
+        <input {...getInputProps()} disabled={disabled} />
+        {children}
+      </Button>
+    </DropzoneContext.Provider>
+  );
+};
+
+const useDropzoneContext = () => {
+  const context = useContext(DropzoneContext);
+
+  if (!context) {
+    throw new Error('useDropzoneContext must be used within a Dropzone');
+  }
+
+  return context;
+};
+
+export type DropzoneContentProps = {
+  children?: ReactNode;
+  className?: string;
+};
+
+const maxLabelItems = 3;
+
+export const DropzoneContent = ({
+  children,
+  className,
+}: DropzoneContentProps) => {
+  const { src } = useDropzoneContext();
+
+  if (!src) {
+    return null;
+  }
+
+  if (children) {
+    return children;
+  }
+
+  return (
+    <div className={cn('flex flex-col items-center justify-center', className)}>
+      <div className="flex size-8 items-center justify-center rounded-md bg-muted text-muted-foreground">
+        <UploadIcon size={16} />
+      </div>
+      <p className="my-2 w-full truncate font-medium text-sm">
+        {src.length > maxLabelItems
+          ? `${new Intl.ListFormat('en').format(
+              src.slice(0, maxLabelItems).map((file) => file.name)
+            )} and ${src.length - maxLabelItems} more`
+          : new Intl.ListFormat('en').format(src.map((file) => file.name))}
+      </p>
+      <p className="w-full text-wrap text-muted-foreground text-xs">
+        Drag and drop or click to replace
+      </p>
+    </div>
+  );
+};
+
+export type DropzoneEmptyStateProps = {
+  children?: ReactNode;
+  className?: string;
+};
+
+export const DropzoneEmptyState = ({
+  children,
+  className,
+}: DropzoneEmptyStateProps) => {
+  const { src, accept, maxSize, minSize, maxFiles } = useDropzoneContext();
+
+  if (src) {
+    return null;
+  }
+
+  if (children) {
+    return children;
+  }
+
+  let caption = '';
+
+  if (accept) {
+    caption += 'Accepts ';
+    caption += new Intl.ListFormat('en').format(Object.keys(accept));
+  }
+
+  if (minSize && maxSize) {
+    caption += ` between ${renderBytes(minSize)} and ${renderBytes(maxSize)}`;
+  } else if (minSize) {
+    caption += ` at least ${renderBytes(minSize)}`;
+  } else if (maxSize) {
+    caption += ` less than ${renderBytes(maxSize)}`;
+  }
+
+  return (
+    <div className={cn('flex flex-col items-center justify-center', className)}>
+      <div className="flex size-8 items-center justify-center rounded-md bg-muted text-muted-foreground">
+        <UploadIcon size={16} />
+      </div>
+      <p className="my-2 w-full truncate text-wrap font-medium text-sm">
+        Upload {maxFiles === 1 ? 'a file' : 'files'}
+      </p>
+      <p className="w-full truncate text-wrap text-muted-foreground text-xs">
+        Drag and drop or click to upload
+      </p>
+      {caption && (
+        <p className="text-wrap text-muted-foreground text-xs">{caption}.</p>
+      )}
+    </div>
+  );
+};

--- a/commitment/imports/ui/components/ui/label.tsx
+++ b/commitment/imports/ui/components/ui/label.tsx
@@ -1,24 +1,24 @@
+"use client"
+
 import * as React from "react"
 import * as LabelPrimitive from "@radix-ui/react-label"
-import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@ui/lib/utils"
 
-const labelVariants = cva(
-  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-)
-
-const Label = React.forwardRef<
-  React.ElementRef<typeof LabelPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
-    VariantProps<typeof labelVariants>
->(({ className, ...props }, ref) => (
-  <LabelPrimitive.Root
-    ref={ref}
-    className={cn(labelVariants(), className)}
-    {...props}
-  />
-))
-Label.displayName = LabelPrimitive.Root.displayName
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
 
 export { Label }

--- a/commitment/imports/ui/components/ui/radio-group.tsx
+++ b/commitment/imports/ui/components/ui/radio-group.tsx
@@ -1,0 +1,43 @@
+import * as React from "react"
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group"
+import { CircleIcon } from "lucide-react"
+
+import { cn } from "@ui/lib/utils"
+
+function RadioGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Root>) {
+  return (
+    <RadioGroupPrimitive.Root
+      data-slot="radio-group"
+      className={cn("grid gap-3", className)}
+      {...props}
+    />
+  )
+}
+
+function RadioGroupItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
+  return (
+    <RadioGroupPrimitive.Item
+      data-slot="radio-group-item"
+      className={cn(
+        "border-input text-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator
+        data-slot="radio-group-indicator"
+        className="relative flex items-center justify-center"
+      >
+        <CircleIcon className="fill-primary absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  )
+}
+
+export { RadioGroup, RadioGroupItem }

--- a/commitment/package-lock.json
+++ b/commitment/package-lock.json
@@ -15,6 +15,7 @@
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-navigation-menu": "^1.2.12",
         "@radix-ui/react-popover": "^1.1.14",
+        "@radix-ui/react-radio-group": "^1.3.7",
         "@radix-ui/react-scroll-area": "^1.2.9",
         "@radix-ui/react-separator": "^1.1.6",
         "@radix-ui/react-slot": "^1.2.3",
@@ -1577,6 +1578,61 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.7.tgz",
+      "integrity": "sha512-9w5XhD0KPOrm92OTTE0SysH3sYzHsSTHNvZgUBo/VZ80VdYyB5RneDbc0dKpURS24IxkoFRu/hI0i4XyfFwY6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/commitment/package-lock.json
+++ b/commitment/package-lock.json
@@ -35,6 +35,7 @@
         "react": "^18.2.0",
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.2.0",
+        "react-dropzone": "^14.3.8",
         "react-hook-form": "^7.62.0",
         "react-router-dom": "^6.30.0",
         "recharts": "^2.15.3",
@@ -3213,6 +3214,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/attr-accept": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz",
+      "integrity": "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -5006,6 +5016,18 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/file-selector": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-2.1.2.tgz",
+      "integrity": "sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/fill-range": {
@@ -8395,6 +8417,23 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-dropzone": {
+      "version": "14.3.8",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.3.8.tgz",
+      "integrity": "sha512-sBgODnq+lcA4P296DY4wacOZz3JFpD99fp+hb//iBO2HHnyeZU3FwWyXJ6salNpqQdsZrgMrotuko/BdJMV8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "attr-accept": "^2.2.4",
+        "file-selector": "^2.1.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8 || 18.0.0"
       }
     },
     "node_modules/react-hook-form": {

--- a/commitment/package-lock.json
+++ b/commitment/package-lock.json
@@ -47,6 +47,8 @@
       "devDependencies": {
         "@meteorjs/eslint-config-meteor": "^1.0.5",
         "@tailwindcss/postcss": "^4.1.11",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
         "@types/mocha": "^8.2.3",
         "@types/node": "^18.19.121",
         "@types/react": "^18.3.23",
@@ -55,6 +57,7 @@
         "@typescript-eslint/parser": "^8.38.0",
         "babel-eslint": "^10.1.0",
         "babel-plugin-module-resolver": "^5.0.2",
+        "chai": "^5.2.1",
         "eslint": "^8.57.1",
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-prettier": "^10.1.8",
@@ -63,9 +66,11 @@
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-meteor": "^7.3.0",
         "eslint-plugin-react": "^7.37.5",
+        "jsdom": "^26.1.0",
         "mocha": "^11.7.1",
         "postcss": "^8.5.3",
         "postcss-load-config": "^6.0.1",
+        "sinon": "^21.0.0",
         "tailwindcss": "^4.1.11",
         "typescript": "^4.9.5"
       }
@@ -95,6 +100,20 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -233,6 +252,121 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
+      "integrity": "sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.10.tgz",
+      "integrity": "sha512-TiJ5Ajr6WRd1r8HSiwJvZBiJOqtH86aHpUjq5aEKWHiII2Qfjqd/HCWKPOW8EP4vcspXbHnXrwIDlu5savQipg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.0.2",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2277,6 +2411,47 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+      "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.3.tgz",
+      "integrity": "sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "type-detect": "^4.1.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@standard-schema/utils": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
@@ -2558,6 +2733,71 @@
         "postcss": "^8.4.41",
         "tailwindcss": "4.1.11"
       }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
+      "integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/d3-array": {
       "version": "3.2.1",
@@ -2962,6 +3202,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -3195,6 +3445,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ast-types-flow": {
@@ -3450,6 +3710,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/chai": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.1.tgz",
+      "integrity": "sha512-5nFxhUrX0PqtyogoYOA8IPswy5sZFTOsBFl/9bNsmDLgsxYTzSZQJDPppDnZPTQbzSEm0hqGjWPzRemQCYbD6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3478,6 +3755,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -3660,6 +3947,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -3794,6 +4095,20 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -3889,11 +4204,28 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -3938,6 +4270,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -3976,6 +4318,13 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -4056,6 +4405,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -5462,6 +5824,60 @@
         "@babel/runtime": "^7.7.6"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5828,6 +6244,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -6061,6 +6484,46 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -6478,6 +6941,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.0.tgz",
+      "integrity": "sha512-2NCfZcT5VGVNX9mSZIxLRkEAegDGBpuQZBy13desuHeVORmBDyAET4TkJr4SjqQy3A8JDofMN6LpkK8Xcm/dlw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -6492,6 +6962,16 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -7916,6 +8396,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.21",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.21.tgz",
+      "integrity": "sha512-o6nIY3qwiSXl7/LuOU0Dmuctd34Yay0yeuZRLFmDPrrdHpXKFndPj3hM+YEPVHYC5fx2otBx4Ilc/gyYSAUaIA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -8143,6 +8630,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -8195,6 +8695,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -8321,6 +8831,51 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -8808,6 +9363,13 @@
         "node": "*"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -8915,6 +9477,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -9105,6 +9687,37 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sinon": {
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-21.0.0.tgz",
+      "integrity": "sha512-TOgRcwFPbfGtpqvZw+hyqJDvqfapr1qUlOizROIk4bBLjlsjlB00Pg6wMFXNtJRpu+eCZuVOaLatG7M8105kAw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.5",
+        "@sinonjs/samsam": "^8.0.1",
+        "diff": "^7.0.0",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/source-map-js": {
@@ -9400,6 +10013,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwind-merge": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.2.0.tgz",
@@ -9466,6 +10086,26 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -9477,6 +10117,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ts-api-utils": {
@@ -9535,6 +10201,16 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-fest": {
@@ -9741,6 +10417,66 @@
         "d3-shape": "^3.1.0",
         "d3-time": "^3.0.0",
         "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -9966,6 +10702,45 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/commitment/package-lock.json
+++ b/commitment/package-lock.json
@@ -7,12 +7,12 @@
       "name": "meteor-app",
       "dependencies": {
         "@babel/runtime": "^7.20.7",
-        "@hookform/resolvers": "^5.0.1",
+        "@hookform/resolvers": "^5.2.1",
         "@radix-ui/react-accordion": "^1.2.8",
         "@radix-ui/react-alert-dialog": "^1.1.14",
         "@radix-ui/react-checkbox": "^1.2.3",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
-        "@radix-ui/react-label": "^2.1.6",
+        "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-navigation-menu": "^1.2.12",
         "@radix-ui/react-popover": "^1.1.14",
         "@radix-ui/react-scroll-area": "^1.2.9",
@@ -33,13 +33,13 @@
         "react": "^18.2.0",
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.2.0",
-        "react-hook-form": "^7.56.1",
+        "react-hook-form": "^7.62.0",
         "react-router-dom": "^6.30.0",
         "recharts": "^2.15.3",
         "rxjs": "^7.8.2",
         "tailwind-merge": "^3.2.0",
         "tailwindcss-animate": "^1.0.7",
-        "zod": "^3.24.3"
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@meteorjs/eslint-config-meteor": "^1.0.5",
@@ -371,9 +371,9 @@
       "license": "MIT"
     },
     "node_modules/@hookform/resolvers": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.0.1.tgz",
-      "integrity": "sha512-u/+Jp83luQNx9AdyW2fIPGY6Y7NG68eN2ZW8FOJYL+M0i4s49+refdJdOp/A9n9HFQtQs3HIDHQvX3ZET2o7YA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.1.tgz",
+      "integrity": "sha512-u0+6X58gkjMcxur1wRWokA7XsiiBJ6aK17aPZxhkoYiK5J+HcTx0Vhu9ovXe6H+dVpO6cjrn2FkJTryXEMlryQ==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/utils": "^0.3.0"
@@ -8341,9 +8341,9 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.56.4",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.56.4.tgz",
-      "integrity": "sha512-Rob7Ftz2vyZ/ZGsQZPaRdIefkgOSrQSPXfqBdvOPwJfoGnjwRJUs7EM7Kc1mcoDv3NOtqBzPGbcMB8CGn9CKgw==",
+      "version": "7.62.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.62.0.tgz",
+      "integrity": "sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -10010,9 +10010,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.30",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.30.tgz",
-      "integrity": "sha512-VolhdEtu6TJr/fzGuHA/SZ5ixvXqA6ADOG9VRcQ3rdOKmF5hkmcJbyaQjUH5BgmpA9gej++zYRX7zjSmdReIwA==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/commitment/package-lock.json
+++ b/commitment/package-lock.json
@@ -11,6 +11,7 @@
         "@radix-ui/react-accordion": "^1.2.8",
         "@radix-ui/react-alert-dialog": "^1.1.14",
         "@radix-ui/react-checkbox": "^1.2.3",
+        "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-navigation-menu": "^1.2.12",

--- a/commitment/package.json
+++ b/commitment/package.json
@@ -20,6 +20,7 @@
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-navigation-menu": "^1.2.12",
     "@radix-ui/react-popover": "^1.1.14",
+    "@radix-ui/react-radio-group": "^1.3.7",
     "@radix-ui/react-scroll-area": "^1.2.9",
     "@radix-ui/react-separator": "^1.1.6",
     "@radix-ui/react-slot": "^1.2.3",

--- a/commitment/package.json
+++ b/commitment/package.json
@@ -12,12 +12,12 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.20.7",
-    "@hookform/resolvers": "^5.0.1",
+    "@hookform/resolvers": "^5.2.1",
     "@radix-ui/react-accordion": "^1.2.8",
     "@radix-ui/react-alert-dialog": "^1.1.14",
     "@radix-ui/react-checkbox": "^1.2.3",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
-    "@radix-ui/react-label": "^2.1.6",
+    "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-navigation-menu": "^1.2.12",
     "@radix-ui/react-popover": "^1.1.14",
     "@radix-ui/react-scroll-area": "^1.2.9",
@@ -38,13 +38,13 @@
     "react": "^18.2.0",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.2.0",
-    "react-hook-form": "^7.56.1",
+    "react-hook-form": "^7.62.0",
     "react-router-dom": "^6.30.0",
     "recharts": "^2.15.3",
     "rxjs": "^7.8.2",
     "tailwind-merge": "^3.2.0",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^3.24.3"
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@meteorjs/eslint-config-meteor": "^1.0.5",

--- a/commitment/package.json
+++ b/commitment/package.json
@@ -40,6 +40,7 @@
     "react": "^18.2.0",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.2.0",
+    "react-dropzone": "^14.3.8",
     "react-hook-form": "^7.62.0",
     "react-router-dom": "^6.30.0",
     "recharts": "^2.15.3",

--- a/commitment/package.json
+++ b/commitment/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-accordion": "^1.2.8",
     "@radix-ui/react-alert-dialog": "^1.1.14",
     "@radix-ui/react-checkbox": "^1.2.3",
+    "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-navigation-menu": "^1.2.12",

--- a/commitment/package.json
+++ b/commitment/package.json
@@ -52,6 +52,8 @@
   "devDependencies": {
     "@meteorjs/eslint-config-meteor": "^1.0.5",
     "@tailwindcss/postcss": "^4.1.11",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
     "@types/mocha": "^8.2.3",
     "@types/node": "^18.19.121",
     "@types/react": "^18.3.23",
@@ -60,6 +62,7 @@
     "@typescript-eslint/parser": "^8.38.0",
     "babel-eslint": "^10.1.0",
     "babel-plugin-module-resolver": "^5.0.2",
+    "chai": "^5.2.1",
     "eslint": "^8.57.1",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^10.1.8",
@@ -68,9 +71,11 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-meteor": "^7.3.0",
     "eslint-plugin-react": "^7.37.5",
+    "jsdom": "^26.1.0",
     "mocha": "^11.7.1",
     "postcss": "^8.5.3",
     "postcss-load-config": "^6.0.1",
+    "sinon": "^21.0.0",
     "tailwindcss": "^4.1.11",
     "typescript": "^4.9.5"
   },


### PR DESCRIPTION
# Scaling Config Form
## High-Level Description

This PR implements the first step of a multi-step flow for generating scaling configurations. 
It introduces a dialog-based form that captures the user's selection of scaling metrics, method, and optional custom script upload, integrated into the main scaling page.

---

## Purpose of the Change

This change enables users to define how grades should be scaled by selecting from a range of metrics and methods.
On first visit to the page, users are guided through the configuration flow before accessing scaling results. 
This helps standardize the process of creating new scaling models and ensures important inputs are collected upfront.

---

## Implementation Details

Introduced a ScalingConfigForm component that:
- Uses `shadcn/ui components` (Form, Checkbox, RadioGroup, and custom Dropzone) for consistent UI.
- Validates required fields using react-hook-form.
- Allows optional .py file uploads as custom scaling scripts.
- Manages flow state using local state and localStorage to track first visit.
- Uses the Dialog component to display and control progression through the steps:
  - Scaling Config Form
  - Grade Sheet Upload (to be implemented)
  - Display of results (to be implemented)

The form is only shown on the first visit. 
On subsequent visits, existing scalings are displayed with an option to "Create New Scaling," which triggers the dialog again.
This change only introduces the basis of the logic for scaling creation and validation, presenting the first form where the configurations for scaling are selected. 
The remaining logic will be introduced in subsequent updates.

See **SC1** for a reference to what this change is ideally meant to look like. Let Arosh know if you are unhappy with his implementation and he will strive to improve it.

---

## Steps to Test (if applicable)

_Include clear steps to verify or test this change. Feel free to include test cases, commands, or browser actions._

1. Switch to this branch `feat/initial-scaling-page`.
2. Enter the Docker container and run `npm install`.
3. Run the application with `meteor`.
4. Switch to the `localhost:3000/metrics` route (or equivalent, depending on which port is exposed.
5. Select the `Scaling` tab and observe that the dialog should display straight away, as per **SC2**.
6. Attempt to submit the form without selecting a scaling metric; this should result in an error as per **SC3**.
7. Attempt to upload a Python file via drag, and then by pressing on the box and selecting from file.
  a. In both instances, it should only let you insert a file with the .py extension.
  b. Should only allow you to insert one file. 
  c. Refer to **SC4** for reference on how the drop box should look when a Python file has been inserted.
8. Ensure that the scaling metric is selected and submit the form.
  a. User should be redirected to the Grading Sheet Upload dialog (which is currently incomplete, see **SC5**).
  b. Right-click and `inspect`, see console output should be details entered in config options, similar to **SC6**.
---

## Screenshots (if applicable)

### SC1
<img width="1140" height="745" alt="image" src="https://github.com/user-attachments/assets/f2dde55f-65e9-435b-8246-9476c9284598" />

### SC2
<img width="1920" height="1032" alt="modal sc" src="https://github.com/user-attachments/assets/bee58d61-bb08-4035-b9a7-be7be375adbf" />

### SC3
<img width="1920" height="1032" alt="error" src="https://github.com/user-attachments/assets/a4795527-fad8-4d72-9b8a-5865a3505746" />

### SC4
<img width="1920" height="1032" alt="py upload" src="https://github.com/user-attachments/assets/8bb3a79a-7ae5-4a5d-b258-ff9c8abec531" />

### SC5
<img width="1920" height="1032" alt="gs" src="https://github.com/user-attachments/assets/88773e88-c5fb-4fd0-8e90-8e903b3dd2ef" />

### SC6
<img width="581" height="165" alt="config submitted" src="https://github.com/user-attachments/assets/faa26ab4-629e-4b5c-9279-faedb6d4e905" />

---

## Linked Issue/Story

[86czv7w99](https://app.clickup.com/t/86czv7w99)