### PR TITLE
Scaling Output Page

### DIFF
--- a/commitment/imports/ui/App.tsx
+++ b/commitment/imports/ui/App.tsx
@@ -8,6 +8,7 @@ import MetricsMain from "./MetricsMain";
 import DashboardView from "./views/DashboardView/DashboardView";
 
 
+
 export const App = () => {
   return (
     <BrowserRouter>
@@ -21,6 +22,7 @@ export const App = () => {
         <Route path="/loading" element={<LoadingPage/>}></Route>
         <Route path="/metrics" element={<MetricsMain />}></Route>
         <Route path="/dashboard" element={<DashboardView/>}></Route>
+        
         
       </Routes>
     </BrowserRouter>

--- a/commitment/imports/ui/components/landing-page/NavBar.tsx
+++ b/commitment/imports/ui/components/landing-page/NavBar.tsx
@@ -26,6 +26,8 @@ export const NavBar: React.FC<NavBarProps> = ({ isLoggedIn }) => {
 
   const handleToggleDarkMode = () => {
     setIsDarkMode(!isDarkMode);
+
+    document.documentElement.classList.toggle("dark");
     // note to self: implement dark mode logic here later
     console.log("Dark mode toggled:", !isDarkMode);
   };
@@ -33,7 +35,11 @@ export const NavBar: React.FC<NavBarProps> = ({ isLoggedIn }) => {
   return (
     <div
       className={`z-50 flex items-center justify-between py-2 border-b bg-white  
-        ${isLandingPage ? "sticky top-0 px-4 rounded-md shadow-lg  ml-32 mr-32" : "relative px-4"}
+        ${
+          isLandingPage
+            ? "sticky top-0 px-4 rounded-md shadow-lg  ml-32 mr-32"
+            : "relative px-4"
+        }
       `}
     >
       <NavigationMenu>
@@ -73,9 +79,13 @@ export const NavBar: React.FC<NavBarProps> = ({ isLoggedIn }) => {
             <>
               <NavigationMenuItem>
                 <NavigationMenuLink>
-                <Link to="/dashboard" className={navigationMenuTriggerStyle()}>
+                  <Link
+                    to="/dashboard"
+                    className={navigationMenuTriggerStyle()}
+                  >
                     Dashboard
-                  </Link>                </NavigationMenuLink>
+                  </Link>{" "}
+                </NavigationMenuLink>
               </NavigationMenuItem>
               <NavigationMenuItem>
                 <NavigationMenuLink>

--- a/commitment/imports/ui/components/scaling/GradingSheetForm.tsx
+++ b/commitment/imports/ui/components/scaling/GradingSheetForm.tsx
@@ -1,5 +1,46 @@
-import React from "react";
+import React, { useState, ChangeEvent } from 'react';
+import { Button } from '../ui/button';
 
-export const GradingSheetForm = () => {
-  return <div>GRADING SHEET FORM</div>;
+interface GradingSheetFormProps {
+  onSubmit: (file: File) => void;
+}
+
+export const GradingSheetForm: React.FC<GradingSheetFormProps> = ({ onSubmit }) => {
+  const [file, setFile] = useState<File | null>(null);
+
+  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files.length > 0) {
+      setFile(e.target.files[0]);
+    }
+  };
+
+  const handleSubmit = () => {
+    if (file) {
+      onSubmit(file);
+    } else {
+      alert('Please upload a file before submitting.');
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <label className="block text-sm font-medium text-gray-700">
+          Upload Grading Sheet
+        </label>
+        <input
+          type="file"
+          accept=".csv,.xlsx,.xls"
+          onChange={handleFileChange}
+          className="mt-1 block w-full"
+        />
+      </div>
+      <Button
+        className="bg-git-int-primary text-git-int-text hover:bg-git-int-primary-hover"
+        onClick={handleSubmit}
+      >
+        Submit
+      </Button>
+    </div>
+  );
 };

--- a/commitment/imports/ui/components/scaling/GradingSheetForm.tsx
+++ b/commitment/imports/ui/components/scaling/GradingSheetForm.tsx
@@ -1,11 +1,13 @@
-import React, { useState, ChangeEvent } from 'react';
-import { Button } from '../ui/button';
+import React, { useState, ChangeEvent } from "react";
+import { Button } from "../ui/button";
 
 interface GradingSheetFormProps {
   onSubmit: (file: File) => void;
 }
 
-export const GradingSheetForm: React.FC<GradingSheetFormProps> = ({ onSubmit }) => {
+export const GradingSheetForm: React.FC<GradingSheetFormProps> = ({
+  onSubmit,
+}) => {
   const [file, setFile] = useState<File | null>(null);
 
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
@@ -18,7 +20,7 @@ export const GradingSheetForm: React.FC<GradingSheetFormProps> = ({ onSubmit }) 
     if (file) {
       onSubmit(file);
     } else {
-      alert('Please upload a file before submitting.');
+      alert("Please upload a file before submitting.");
     }
   };
 

--- a/commitment/imports/ui/components/scaling/ScalingRadialChart.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingRadialChart.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import React from "react";
+import {
+  RadialBarChart,
+  RadialBar,
+  PolarAngleAxis,
+} from "recharts";
+
+interface ScalingRadialChartProps {
+  value: number; // 0 to 1
+}
+
+export function ScalingRadialChart({ value }: ScalingRadialChartProps) {
+  const percentage = Math.max(0, Math.min(1, value)); // clamp to [0, 1]
+  const chartData = [
+    {
+      name: "scale",
+      value: percentage * 100,
+      fill: "#3B82F6",
+    },
+  ];
+
+  return (
+    <div className="w-16 h-16"> {/* 64px container */}
+      <RadialBarChart
+        width={64}
+        height={64}
+        cx="50%"
+        cy="50%"
+        innerRadius="80%"
+        outerRadius="100%"
+        barSize={8}
+        data={chartData}
+        startAngle={90}
+        endAngle={-270}
+      >
+        <PolarAngleAxis
+          type="number"
+          domain={[0, 100]}
+          angleAxisId={0}
+          tick={false}
+        />
+        <RadialBar
+          background={{ fill: "transparent" }}
+          clockWise
+          minAngle={0}
+          dataKey="value"
+          angleAxisId={0}
+          cornerRadius={5}
+        />
+        <text
+          x="50%"
+          y="50%"
+          textAnchor="middle"
+          dominantBaseline="middle"
+          style={{
+            fill: "#ffffff",
+            fontSize: "0.7rem",
+            fontWeight: "bold",
+            
+          }}
+        >
+          {(value * 100).toFixed(0)}%
+        </text>
+      </RadialBarChart>
+    </div>
+  );
+}
+
+

--- a/commitment/imports/ui/components/scaling/ScalingRadialChart.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingRadialChart.tsx
@@ -1,16 +1,17 @@
 "use client";
 
 import React from "react";
-import {
-  RadialBarChart,
-  RadialBar,
-  PolarAngleAxis,
-} from "recharts";
+import { RadialBarChart, RadialBar, PolarAngleAxis } from "recharts";
 
 interface ScalingRadialChartProps {
   value: number; // 0 to 1
 }
 
+/**
+ * 
+ * @param value 
+ * @returns Radial Chart Component
+ */
 export function ScalingRadialChart({ value }: ScalingRadialChartProps) {
   const percentage = Math.max(0, Math.min(1, value)); // clamp to [0, 1]
   const chartData = [
@@ -22,7 +23,9 @@ export function ScalingRadialChart({ value }: ScalingRadialChartProps) {
   ];
 
   return (
-    <div className="w-16 h-16"> {/* 64px container */}
+    <div className="w-16 h-16">
+      {" "}
+      {/* 64px container */}
       <RadialBarChart
         width={64}
         height={64}
@@ -58,7 +61,6 @@ export function ScalingRadialChart({ value }: ScalingRadialChartProps) {
             fill: "#ffffff",
             fontSize: "0.7rem",
             fontWeight: "bold",
-            
           }}
         >
           {value}
@@ -67,5 +69,3 @@ export function ScalingRadialChart({ value }: ScalingRadialChartProps) {
     </div>
   );
 }
-
-

--- a/commitment/imports/ui/components/scaling/ScalingRadialChart.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingRadialChart.tsx
@@ -17,7 +17,7 @@ export function ScalingRadialChart({ value }: ScalingRadialChartProps) {
     {
       name: "scale",
       value: percentage * 100,
-      fill: "#3B82F6",
+      fill: "var(--git-dv-blue)",
     },
   ];
 
@@ -61,7 +61,7 @@ export function ScalingRadialChart({ value }: ScalingRadialChartProps) {
             
           }}
         >
-          {(value * 100).toFixed(0)}%
+          {value}
         </text>
       </RadialBarChart>
     </div>

--- a/commitment/imports/ui/components/scaling/ScalingRadialChart.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingRadialChart.tsx
@@ -8,8 +8,8 @@ interface ScalingRadialChartProps {
 }
 
 /**
- * 
- * @param value 
+ *
+ * @param value
  * @returns Radial Chart Component
  */
 export function ScalingRadialChart({ value }: ScalingRadialChartProps) {
@@ -57,11 +57,7 @@ export function ScalingRadialChart({ value }: ScalingRadialChartProps) {
           y="50%"
           textAnchor="middle"
           dominantBaseline="middle"
-          style={{
-            fill: "#ffffff",
-            fontSize: "0.7rem",
-            fontWeight: "bold",
-          }}
+          className="fill-git-int-text text-[0.7rem] font-bold"
         >
           {value}
         </text>

--- a/commitment/imports/ui/components/scaling/ScalingRadialChart.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingRadialChart.tsx
@@ -8,7 +8,6 @@ interface ScalingRadialChartProps {
 }
 
 /**
- *
  * @param value
  * @returns Radial Chart Component
  */

--- a/commitment/imports/ui/components/scaling/ScalingSummary.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingSummary.tsx
@@ -6,20 +6,7 @@ import { ColumnDef } from "@tanstack/react-table";
 import { ScalingRadialChart } from "./ScalingRadialChart";
 import type { UserScalingSummary } from "@server/commitment_api/types";
 
-
-
-
 interface ScalingSummaryProps {
-  //      An example entry
-  //     {
-  //     name: "Jupyta Notebuk",
-  //     aliases: [
-  //       { username: "Bobert", email: "bobert@example.com" },
-  //       { username: "john", email: "john@example.com" },
-  //     ],
-  //     finalGrade: 78,
-  //     scale: 1,
-  //   }
   userScalingSummaries: UserScalingSummary[];
 }
 

--- a/commitment/imports/ui/components/scaling/ScalingSummary.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingSummary.tsx
@@ -17,105 +17,57 @@ type UserScalingSummary = {
   scale: number;
 };
 
+
 interface ScalingSummaryProps {
-  method: string;
-  metrics: string;
-  fileName: string | null;
+  //      An example entry
+  //     {
+  //     name: "Jupyta Notebuk",
+  //     aliases: [
+  //       { username: "Bobert", email: "bobert@example.com" },
+  //       { username: "john", email: "john@example.com" },
+  //     ],
+  //     finalGrade: 78,
+  //     scale: 1,
+  //   }
+  userScalingSummaries: UserScalingSummary[];
 }
 
-const ScalingSummary: React.FC<ScalingSummaryProps> = ({ method, metrics, fileName }) => {
-  const userScalingSummaries: UserScalingSummary[] = useMemo(() => [
-    {
-      name: "Jupyta Notebuk",
-      aliases: [
-        { username: "Bobert", email: "bobert@example.com" },
-        { username: "john", email: "john@example.com" },
-      ],
-      finalGrade: 78,
-      scale: 1,
-    },
-    {
-      name: "Poppy Willis",
-      aliases: [
-        { username: "capn america", email: "cap@example.com" },
-        { username: "iyan man", email: "iyan@example.com" },
-      ],
-      finalGrade: 42,
-      scale: 0.66,
-    },
-    {
-      name: "Jupyta Notebuk",
-      aliases: [
-        { username: "Bobert", email: "bobert@example.com" },
-        { username: "john", email: "john@example.com" },
-      ],
-      finalGrade: 78,
-      scale: 1,
-    },
-    {
-      name: "Poppy Willis",
-      aliases: [
-        { username: "capn america", email: "cap@example.com" },
-        { username: "iyan man", email: "iyan@example.com" },
-      ],
-      finalGrade: 42,
-      scale: 0.66,
-    },
-    {
-      name: "Jupyta Notebuk",
-      aliases: [
-        { username: "Bobert", email: "bobert@example.com" },
-        { username: "john", email: "john@example.com" },
-      ],
-      finalGrade: 78,
-      scale: 1,
-    },
-    {
-      name: "Poppy Willis",
-      aliases: [
-        { username: "capn america", email: "cap@example.com" },
-        { username: "iyan man", email: "iyan@example.com" },
-      ],
-      finalGrade: 42,
-      scale: 0.66,
-    },
-  ], []);
-
-  const columns: ColumnDef<UserScalingSummary>[] = useMemo(() => [
-    {
-      accessorKey: "name",
-      header: "Contributor Name",
-      cell: ({ row }) => row.getValue("name"),
-    },
-    {
-      accessorKey: "finalGrade",
-      header: "Final Grade",
-      cell: ({ row }) => row.getValue("finalGrade"),
-    },
-    {
-    accessorKey: "scale",
-    header: "Scale",
-    cell: ({ row }) => (
-        <ScalingRadialChart value={row.getValue("scale")} /> 
-    ),
-    }, 
-
-  ], []);
+/**
+ * 
+ * @param  userScalingSummaries contain the details of each person, their aliases with emails, their grade and the scaling applied to their grade.  
+ * @returns 
+ */
+const ScalingSummary: React.FC<ScalingSummaryProps> = ({
+  userScalingSummaries,
+}) => {
+  const columns: ColumnDef<UserScalingSummary>[] = useMemo(
+    () => [
+      {
+        accessorKey: "name",
+        header: "Contributor Name",
+        cell: ({ row }) => row.getValue("name"),
+      },
+      {
+        accessorKey: "finalGrade",
+        header: "Final Grade",
+        cell: ({ row }) => row.getValue("finalGrade"),
+      },
+      {
+        accessorKey: "scale",
+        header: "Scale",
+        cell: ({ row }) => <ScalingRadialChart value={row.getValue("scale")} />,
+      },
+    ],
+    []
+  );
 
   return (
     <div className="-mt-4 p-4 rounded-md bg-git-bg-elevated">
-      {/* <h2 className="text-xl font-semibold mb-2">Scaling Summary</h2>
-      <p><strong>Method:</strong> {method}</p>
-      <p><strong>Metrics:</strong> {metrics}</p>
-      <p><strong>Grading Sheet:</strong> {fileName}</p> */}
-
       <div className="max-h-[600px]  rounded-md bg-git-bg-elevated">
         <DataTable columns={columns} data={userScalingSummaries} />
       </div>
-
     </div>
   );
 };
 
 export default ScalingSummary;
-

--- a/commitment/imports/ui/components/scaling/ScalingSummary.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingSummary.tsx
@@ -1,0 +1,78 @@
+"use client"
+
+
+import React, { useMemo } from "react";
+import { DataTable } from "./ScalingTable";
+import { ColumnDef } from "@tanstack/react-table";
+
+type UserScalingSummary = {
+  name: string;
+  aliases: string[];
+  finalGrade: number;
+  scale: number;
+};
+
+interface ScalingSummaryProps {
+  method: string;
+  metrics: string;
+  fileName: string;
+}
+
+const ScalingSummary: React.FC<ScalingSummaryProps> = ({ method, metrics, fileName }) => {
+  const userScalingSummaries: UserScalingSummary[] = useMemo(() => [
+    {
+      name: "Jupyta Notebuk",
+      aliases: ["Bobert", "john"],
+      finalGrade: 78,
+      scale: 1.2,
+    },
+    {
+      name: "Poppy Willis",
+      aliases: ["capn america", "iyan man"],
+      finalGrade: 42,
+      scale: 0.8,
+    },
+  ], []);
+
+  const columns: ColumnDef<UserScalingSummary>[] = useMemo(() => [
+    {
+      accessorKey: "name",
+      header: "Name",
+      cell: ({ row }) => row.getValue("name"),
+    },
+    {
+      accessorKey: "finalGrade",
+      header: "Final Grade",
+      cell: ({ row }) => row.getValue("finalGrade"),
+    },
+    {
+      accessorKey: "scale",
+      header: "Scale",
+      cell: ({ row }) => row.getValue("scale"),
+    },
+    {
+      accessorKey: "aliases",
+      header: "Aliases",
+      cell: ({ row }) => {
+        const aliases = row.getValue("aliases");
+        return Array.isArray(aliases) ? aliases.join(", ") : "—";
+      },
+    },
+  ], []);
+
+  return (
+    <div className="mt-8 p-4 border rounded-md bg-gray-50">
+      <h2 className="text-xl font-semibold mb-2">Scaling Summary</h2>
+      <p><strong>Method:</strong> {method}</p>
+      <p><strong>Metrics:</strong> {metrics}</p>
+      <p><strong>Grading Sheet:</strong> {fileName}</p>
+
+      <div className="container mx-auto py-10">
+        <DataTable columns={columns} data={userScalingSummaries} />
+      </div>
+    </div>
+  );
+};
+
+export default ScalingSummary;
+"use client"

--- a/commitment/imports/ui/components/scaling/ScalingSummary.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingSummary.tsx
@@ -4,18 +4,9 @@ import React, { useMemo } from "react";
 import { DataTable } from "./ScalingTable";
 import { ColumnDef } from "@tanstack/react-table";
 import { ScalingRadialChart } from "./ScalingRadialChart";
+import type { UserScalingSummary } from "@server/commitment_api/types";
 
-type AliasEmail = {
-  username: string;
-  email: string;
-};
 
-type UserScalingSummary = {
-  name: string;
-  aliases: AliasEmail[];
-  finalGrade: number;
-  scale: number;
-};
 
 
 interface ScalingSummaryProps {
@@ -33,9 +24,9 @@ interface ScalingSummaryProps {
 }
 
 /**
- * 
- * @param  userScalingSummaries contain the details of each person, their aliases with emails, their grade and the scaling applied to their grade.  
- * @returns 
+ *
+ * @param  userScalingSummaries contain the details of each person, their aliases with emails, their grade and the scaling applied to their grade.
+ * @returns
  */
 const ScalingSummary: React.FC<ScalingSummaryProps> = ({
   userScalingSummaries,
@@ -62,7 +53,7 @@ const ScalingSummary: React.FC<ScalingSummaryProps> = ({
   );
 
   return (
-    <div className="-mt-4 p-4 rounded-md bg-git-bg-elevated">
+    <div className="-mt-4  rounded-md bg-git-bg-elevated ">
       <div className="max-h-[600px]  rounded-md bg-git-bg-elevated">
         <DataTable columns={columns} data={userScalingSummaries} />
       </div>

--- a/commitment/imports/ui/components/scaling/ScalingSummary.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingSummary.tsx
@@ -67,13 +67,13 @@ const ScalingSummary: React.FC<ScalingSummaryProps> = ({ method, metrics, fileNa
   ], []);
 
   return (
-    <div className="mt-8 p-4 border rounded-md bg-gray-50">
-      <h2 className="text-xl font-semibold mb-2">Scaling Summary</h2>
+    <div className="-mt-4 p-4 border rounded-md bg-gray-50">
+      {/* <h2 className="text-xl font-semibold mb-2">Scaling Summary</h2>
       <p><strong>Method:</strong> {method}</p>
       <p><strong>Metrics:</strong> {metrics}</p>
-      <p><strong>Grading Sheet:</strong> {fileName}</p>
+      <p><strong>Grading Sheet:</strong> {fileName}</p> */}
 
-      <div className="container mx-auto py-10">
+      <div className="container py-10 -mt-8 -mb-8">
         <DataTable columns={columns} data={userScalingSummaries} />
       </div>
 

--- a/commitment/imports/ui/components/scaling/ScalingSummary.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingSummary.tsx
@@ -1,13 +1,17 @@
-"use client"
-
+"use client";
 
 import React, { useMemo } from "react";
 import { DataTable } from "./ScalingTable";
 import { ColumnDef } from "@tanstack/react-table";
 
+type AliasEmail = {
+  username: string;
+  email: string;
+};
+
 type UserScalingSummary = {
   name: string;
-  aliases: string[];
+  aliases: AliasEmail[];
   finalGrade: number;
   scale: number;
 };
@@ -22,13 +26,19 @@ const ScalingSummary: React.FC<ScalingSummaryProps> = ({ method, metrics, fileNa
   const userScalingSummaries: UserScalingSummary[] = useMemo(() => [
     {
       name: "Jupyta Notebuk",
-      aliases: ["Bobert", "john"],
+      aliases: [
+        { username: "Bobert", email: "bobert@example.com" },
+        { username: "john", email: "john@example.com" },
+      ],
       finalGrade: 78,
       scale: 1.2,
     },
     {
       name: "Poppy Willis",
-      aliases: ["capn america", "iyan man"],
+      aliases: [
+        { username: "capn america", email: "cap@example.com" },
+        { username: "iyan man", email: "iyan@example.com" },
+      ],
       finalGrade: 42,
       scale: 0.8,
     },
@@ -50,14 +60,6 @@ const ScalingSummary: React.FC<ScalingSummaryProps> = ({ method, metrics, fileNa
       header: "Scale",
       cell: ({ row }) => row.getValue("scale"),
     },
-    {
-      accessorKey: "aliases",
-      header: "Aliases",
-      cell: ({ row }) => {
-        const aliases = row.getValue("aliases");
-        return Array.isArray(aliases) ? aliases.join(", ") : "—";
-      },
-    },
   ], []);
 
   return (
@@ -75,4 +77,4 @@ const ScalingSummary: React.FC<ScalingSummaryProps> = ({ method, metrics, fileNa
 };
 
 export default ScalingSummary;
-"use client"
+

--- a/commitment/imports/ui/components/scaling/ScalingSummary.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingSummary.tsx
@@ -20,11 +20,47 @@ type UserScalingSummary = {
 interface ScalingSummaryProps {
   method: string;
   metrics: string;
-  fileName: string;
+  fileName: string | null;
 }
 
 const ScalingSummary: React.FC<ScalingSummaryProps> = ({ method, metrics, fileName }) => {
   const userScalingSummaries: UserScalingSummary[] = useMemo(() => [
+    {
+      name: "Jupyta Notebuk",
+      aliases: [
+        { username: "Bobert", email: "bobert@example.com" },
+        { username: "john", email: "john@example.com" },
+      ],
+      finalGrade: 78,
+      scale: 1,
+    },
+    {
+      name: "Poppy Willis",
+      aliases: [
+        { username: "capn america", email: "cap@example.com" },
+        { username: "iyan man", email: "iyan@example.com" },
+      ],
+      finalGrade: 42,
+      scale: 0.66,
+    },
+    {
+      name: "Jupyta Notebuk",
+      aliases: [
+        { username: "Bobert", email: "bobert@example.com" },
+        { username: "john", email: "john@example.com" },
+      ],
+      finalGrade: 78,
+      scale: 1,
+    },
+    {
+      name: "Poppy Willis",
+      aliases: [
+        { username: "capn america", email: "cap@example.com" },
+        { username: "iyan man", email: "iyan@example.com" },
+      ],
+      finalGrade: 42,
+      scale: 0.66,
+    },
     {
       name: "Jupyta Notebuk",
       aliases: [
@@ -48,7 +84,7 @@ const ScalingSummary: React.FC<ScalingSummaryProps> = ({ method, metrics, fileNa
   const columns: ColumnDef<UserScalingSummary>[] = useMemo(() => [
     {
       accessorKey: "name",
-      header: "Name",
+      header: "Contributor Name",
       cell: ({ row }) => row.getValue("name"),
     },
     {
@@ -67,13 +103,13 @@ const ScalingSummary: React.FC<ScalingSummaryProps> = ({ method, metrics, fileNa
   ], []);
 
   return (
-    <div className="-mt-4 p-4 border rounded-md bg-gray-50">
+    <div className="-mt-4 p-4 rounded-md bg-git-bg-elevated">
       {/* <h2 className="text-xl font-semibold mb-2">Scaling Summary</h2>
       <p><strong>Method:</strong> {method}</p>
       <p><strong>Metrics:</strong> {metrics}</p>
       <p><strong>Grading Sheet:</strong> {fileName}</p> */}
 
-      <div className="container py-10 -mt-8 -mb-8">
+      <div className="max-h-[600px]  rounded-md bg-git-bg-elevated">
         <DataTable columns={columns} data={userScalingSummaries} />
       </div>
 

--- a/commitment/imports/ui/components/scaling/ScalingSummary.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingSummary.tsx
@@ -3,6 +3,7 @@
 import React, { useMemo } from "react";
 import { DataTable } from "./ScalingTable";
 import { ColumnDef } from "@tanstack/react-table";
+import { ScalingRadialChart } from "./ScalingRadialChart";
 
 type AliasEmail = {
   username: string;
@@ -31,7 +32,7 @@ const ScalingSummary: React.FC<ScalingSummaryProps> = ({ method, metrics, fileNa
         { username: "john", email: "john@example.com" },
       ],
       finalGrade: 78,
-      scale: 1.2,
+      scale: 1,
     },
     {
       name: "Poppy Willis",
@@ -40,7 +41,7 @@ const ScalingSummary: React.FC<ScalingSummaryProps> = ({ method, metrics, fileNa
         { username: "iyan man", email: "iyan@example.com" },
       ],
       finalGrade: 42,
-      scale: 0.8,
+      scale: 0.66,
     },
   ], []);
 
@@ -56,10 +57,13 @@ const ScalingSummary: React.FC<ScalingSummaryProps> = ({ method, metrics, fileNa
       cell: ({ row }) => row.getValue("finalGrade"),
     },
     {
-      accessorKey: "scale",
-      header: "Scale",
-      cell: ({ row }) => row.getValue("scale"),
-    },
+    accessorKey: "scale",
+    header: "Scale",
+    cell: ({ row }) => (
+        <ScalingRadialChart value={row.getValue("scale")} /> 
+    ),
+    }, 
+
   ], []);
 
   return (
@@ -72,6 +76,7 @@ const ScalingSummary: React.FC<ScalingSummaryProps> = ({ method, metrics, fileNa
       <div className="container mx-auto py-10">
         <DataTable columns={columns} data={userScalingSummaries} />
       </div>
+
     </div>
   );
 };

--- a/commitment/imports/ui/components/scaling/ScalingTable.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingTable.tsx
@@ -88,7 +88,7 @@ export function DataTable<TData extends { aliases?: AliasEmail[] }, TValue>({
                     className="bg-gray-50 border-style: dashed">
                     <TableCell colSpan={columns.length}>
                         <div className="ml-8 text-sm text-gray-700">
-                        ↳ <strong>{alias.username}</strong> ({alias.email})
+                            <strong>{alias.username}</strong> ({alias.email})
                         </div>
                     </TableCell>
                     </TableRow>

--- a/commitment/imports/ui/components/scaling/ScalingTable.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingTable.tsx
@@ -16,6 +16,8 @@ import {
   TableRow,
 } from "@ui/components/ui/table";
 
+import { ChevronRight } from "lucide-react";
+
 type AliasEmail = {
   username: string;
   email: string;
@@ -39,14 +41,17 @@ export function DataTable<TData extends { aliases?: AliasEmail[] }, TValue>({
   });
 
   return (
-    <div className="overflow-hidden rounded-md  bg-git-bg-elevated">
+    <div className="overflow-hidden rounded-md border-git-stroke-primary">
       <Table>
         {/* Table Header */}
         <TableHeader>
           {table.getHeaderGroups().map((headerGroup) => (
             <TableRow key={headerGroup.id}>
               {headerGroup.headers.map((header) => (
-                <TableHead key={header.id} className="font-bold">
+                <TableHead
+                  key={header.id}
+                  className="text-git-text-primary bg-git-int-secondary"
+                >
                   {header.isPlaceholder
                     ? null
                     : flexRender(
@@ -63,7 +68,7 @@ export function DataTable<TData extends { aliases?: AliasEmail[] }, TValue>({
         <TableBody>
           {table.getRowModel().rows.map((row) => (
             <React.Fragment key={row.id}>
-              {/* Undexpanded Rows */}
+              {/* Unexpanded Rows */}
               <TableRow
                 onClick={() => row.toggleExpanded()}
                 className="cursor-pointer"
@@ -73,13 +78,22 @@ export function DataTable<TData extends { aliases?: AliasEmail[] }, TValue>({
                     key={cell.id}
                     className={
                       (idx === 0
-                        ? "rounded-l-md bg-git-int-primary hover:bg-git-int-primary text-white text-1xl"
+                        ? "rounded-l-md bg-git-int-primary hover:bg-git-int-primary text-git-int-text text-1xl"
                         : idx === row.getVisibleCells().length - 1
-                        ? "rounded-r-md bg-git-int-primary hover:bg-git-int-primary text-white"
-                        : "bg-git-int-primary hover:bg-git-int-primary text-white text-2xl font-bold") + //Final Grade is slightly larger and bolder than other text
+                        ? "rounded-r-md bg-git-int-primary hover:bg-git-int-primary text-git-int-text"
+                        : "bg-git-int-primary hover:bg-git-int-primary text-git-int-text text-2xl font-bold") +
                       " py-0"
                     }
                   >
+                    {idx === 0 && (
+                      <ChevronRight
+                        className={`inline-block mr-2 transition-transform duration-200 ${
+                          row.getIsExpanded() ? "rotate-90" : ""
+                        }`}
+                        size={16}
+                      />
+                    )}
+
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                     {idx === row.getVisibleCells().length - 2 && "%"}
                   </TableCell>
@@ -90,26 +104,50 @@ export function DataTable<TData extends { aliases?: AliasEmail[] }, TValue>({
               {row.getIsExpanded() && row.original.aliases?.length > 0 && (
                 <>
                   {/* Row for Associated Accounts */}
-                  <TableRow className="bg-git-bg-elevated hover:bg-git-bg-elevated text-white border-black">
-                    <TableCell colSpan={columns.length}>
-                      <span className="ml-4 font-medium text-gray-800">
-                        Associated Accounts
-                      </span>
+
+                  <TableRow className="bg-git-int-secondary hover:bg-git-int-secondary !border-0 px-4">
+                    <TableCell
+                      colSpan={columns.length}
+                      className="!border-0 p-0"
+                    >
+                      {/* Label */}
+                      <div className="px-4 py-2">
+                        <span className="ml-4 font-medium text-git-text-secondary">
+                          Associated Accounts
+                        </span>
+                      </div>
+
+                      {/* Inset solid black separator */}
+                      <div className=" border-b-2 border-git-stroke-primary mx-5" />
                     </TableCell>
                   </TableRow>
 
                   {/* Rows for Aliases */}
                   {row.original.aliases.map((alias, idx) => (
-                    <TableRow
-                      key={`${row.id}-alias-${idx}`}
-                      className="bg-git-bg-elevated hover:bg-git-bg-elevated border-style: dashed"
-                    >
-                      <TableCell colSpan={columns.length}>
-                        <div className="ml-8 text-sm text-gray-700">
-                          <strong>{alias.username}</strong> ({alias.email})
-                        </div>
-                      </TableCell>
-                    </TableRow>
+                    <React.Fragment key={`${row.id}-alias-${idx}`}>
+                      <TableRow className="bg-git-int-secondary hover:bg-git-int-secondary !border-0">
+                        <TableCell
+                          colSpan={columns.length}
+                          className="!border-0 px-4"
+                        >
+                          <div className="ml-4 text-sm text-git-text-secondary">
+                            <strong>{alias.username}</strong> ({alias.email})
+                          </div>
+                        </TableCell>
+                      </TableRow>
+
+                      {/* Dashed separator, only if not last alias */}
+                      {idx < row.original.aliases.length - 1 && (
+                        <TableRow className="!border-0">
+                          <TableCell
+                            colSpan={columns.length}
+                            className="!border-0 px-4"
+                          >
+                            <div className="h-0.5 border-t-2 border-dashed border-git-stroke-primary mx-1" />
+                          </TableCell>
+                        </TableRow>
+                      )}
+                    </React.Fragment>
                   ))}
                 </>
               )}

--- a/commitment/imports/ui/components/scaling/ScalingTable.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingTable.tsx
@@ -1,13 +1,11 @@
-"use client"
-
 import React from "react";
-
 import {
   ColumnDef,
   flexRender,
   getCoreRowModel,
+  getExpandedRowModel,
   useReactTable,
-} from "@tanstack/react-table"
+} from "@tanstack/react-table";
 
 import {
   Table,
@@ -16,28 +14,29 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from "@ui/components/ui/table"
+} from "@ui/components/ui/table";
 
-interface DataTableProps<TData, TValue> {
-  columns: ColumnDef<TData, TValue>[]
-  data: TData[]
+type AliasEmail = {
+  username: string;
+  email: string;
+};
+
+interface DataTableProps<TData extends { aliases?: AliasEmail[] }, TValue> {
+  columns: ColumnDef<TData, TValue>[];
+  data: TData[];
 }
 
-export function DataTable<TData, TValue>({
+export function DataTable<TData extends { aliases?: AliasEmail[] }, TValue>({
   columns,
   data,
 }: DataTableProps<TData, TValue>) {
-  console.log("Rendering DataTable with data:", data);
-  console.log("Columns:", columns);
-
   const table = useReactTable({
     data,
     columns,
     getCoreRowModel: getCoreRowModel(),
+    getExpandedRowModel: getExpandedRowModel(),
+    getRowCanExpand: () => true,
   });
-
-  console.log("DataTable data", data);
-console.log("DataTable columns", columns);
 
   return (
     <div className="overflow-hidden rounded-md border">
@@ -56,23 +55,44 @@ console.log("DataTable columns", columns);
           ))}
         </TableHeader>
         <TableBody>
-          {table.getRowModel().rows.length > 0 ? (
-            table.getRowModel().rows.map((row) => (
-              <TableRow key={row.id}>
+          {table.getRowModel().rows.map((row) => (
+            <React.Fragment key={row.id}>
+              <TableRow
+                onClick={() => row.toggleExpanded()}
+                className="cursor-pointer hover:bg-gray-100"
+              >
                 {row.getVisibleCells().map((cell) => (
                   <TableCell key={cell.id}>
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </TableCell>
                 ))}
               </TableRow>
-            ))
-          ) : (
-            <TableRow>
-              <TableCell colSpan={columns.length} className="h-24 text-center">
-                No results.
-              </TableCell>
-            </TableRow>
-          )}
+
+              {row.getIsExpanded() && row.original.aliases?.length > 0 && (
+                <>
+                  
+                  <TableRow className="bg-gray-50">
+                    <TableCell colSpan={columns.length}>
+                      <span className="ml-4 font-medium text-gray-800">
+                        Associated Accounts
+                      </span>
+                    </TableCell>
+                  </TableRow>
+
+                  
+                  {row.original.aliases.map((alias, idx) => (
+                    <TableRow key={`${row.id}-alias-${idx}`} className="bg-gray-50">
+                      <TableCell colSpan={columns.length}>
+                        <div className="ml-8 text-sm text-gray-700">
+                          ↳ <strong>{alias.username}</strong> ({alias.email})
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </>
+              )}
+            </React.Fragment>
+          ))}
         </TableBody>
       </Table>
     </div>

--- a/commitment/imports/ui/components/scaling/ScalingTable.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingTable.tsx
@@ -1,0 +1,80 @@
+"use client"
+
+import React from "react";
+
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table"
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@ui/components/ui/table"
+
+interface DataTableProps<TData, TValue> {
+  columns: ColumnDef<TData, TValue>[]
+  data: TData[]
+}
+
+export function DataTable<TData, TValue>({
+  columns,
+  data,
+}: DataTableProps<TData, TValue>) {
+  console.log("Rendering DataTable with data:", data);
+  console.log("Columns:", columns);
+
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  console.log("DataTable data", data);
+console.log("DataTable columns", columns);
+
+  return (
+    <div className="overflow-hidden rounded-md border">
+      <Table>
+        <TableHeader>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <TableRow key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <TableHead key={header.id}>
+                  {header.isPlaceholder
+                    ? null
+                    : flexRender(header.column.columnDef.header, header.getContext())}
+                </TableHead>
+              ))}
+            </TableRow>
+          ))}
+        </TableHeader>
+        <TableBody>
+          {table.getRowModel().rows.length > 0 ? (
+            table.getRowModel().rows.map((row) => (
+              <TableRow key={row.id}>
+                {row.getVisibleCells().map((cell) => (
+                  <TableCell key={cell.id}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))
+          ) : (
+            <TableRow>
+              <TableCell colSpan={columns.length} className="h-24 text-center">
+                No results.
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/commitment/imports/ui/components/scaling/ScalingTable.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingTable.tsx
@@ -46,6 +46,7 @@ export function DataTable<TData extends { aliases?: AliasEmail[] }, TValue>({
             <TableRow key={headerGroup.id}>
               {headerGroup.headers.map((header) => (
                 <TableHead key={header.id}>
+
                   {header.isPlaceholder
                     ? null
                     : flexRender(header.column.columnDef.header, header.getContext())}
@@ -57,12 +58,13 @@ export function DataTable<TData extends { aliases?: AliasEmail[] }, TValue>({
         <TableBody>
           {table.getRowModel().rows.map((row) => (
             <React.Fragment key={row.id}>
-              <TableRow
+                <TableRow
                 onClick={() => row.toggleExpanded()}
-                className="cursor-pointer hover:bg-gray-100"
-              >
+                className="bg-git-int-primary hover:bg-git-int-primary text-white"
+                >
+
                 {row.getVisibleCells().map((cell) => (
-                  <TableCell key={cell.id}>
+                  <TableCell key={cell.id} >
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </TableCell>
                 ))}
@@ -71,7 +73,7 @@ export function DataTable<TData extends { aliases?: AliasEmail[] }, TValue>({
               {row.getIsExpanded() && row.original.aliases?.length > 0 && (
                 <>
                   
-                  <TableRow className="bg-gray-50">
+                  <TableRow className="bg-gray-50 border-b-2 border-black">
                     <TableCell colSpan={columns.length}>
                       <span className="ml-4 font-medium text-gray-800">
                         Associated Accounts
@@ -81,12 +83,14 @@ export function DataTable<TData extends { aliases?: AliasEmail[] }, TValue>({
 
                   
                   {row.original.aliases.map((alias, idx) => (
-                    <TableRow key={`${row.id}-alias-${idx}`} className="bg-gray-50">
-                      <TableCell colSpan={columns.length}>
+                    <TableRow
+                    key={`${row.id}-alias-${idx}`}
+                    className="bg-gray-50 border-style: dashed">
+                    <TableCell colSpan={columns.length}>
                         <div className="ml-8 text-sm text-gray-700">
-                          ↳ <strong>{alias.username}</strong> ({alias.email})
+                        ↳ <strong>{alias.username}</strong> ({alias.email})
                         </div>
-                      </TableCell>
+                    </TableCell>
                     </TableRow>
                   ))}
                 </>

--- a/commitment/imports/ui/components/scaling/ScalingTable.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingTable.tsx
@@ -41,46 +41,55 @@ export function DataTable<TData extends { aliases?: AliasEmail[] }, TValue>({
   return (
     <div className="overflow-hidden rounded-md  bg-git-bg-elevated">
       <Table>
-       <TableHeader>
-        {table.getHeaderGroups().map((headerGroup) => (
+        {/* Table Header */}
+        <TableHeader>
+          {table.getHeaderGroups().map((headerGroup) => (
             <TableRow key={headerGroup.id}>
-            {headerGroup.headers.map((header) => (
+              {headerGroup.headers.map((header) => (
                 <TableHead key={header.id} className="font-bold">
-                {header.isPlaceholder
+                  {header.isPlaceholder
                     ? null
-                    : flexRender(header.column.columnDef.header, header.getContext())}
+                    : flexRender(
+                        header.column.columnDef.header,
+                        header.getContext()
+                      )}
                 </TableHead>
-            ))}
+              ))}
             </TableRow>
-        ))}
+          ))}
         </TableHeader>
 
+        {/* Remainder of Table */}
         <TableBody>
           {table.getRowModel().rows.map((row) => (
             <React.Fragment key={row.id}>
-                <TableRow onClick={() => row.toggleExpanded()} className="cursor-pointer">
+              {/* Undexpanded Rows */}
+              <TableRow
+                onClick={() => row.toggleExpanded()}
+                className="cursor-pointer"
+              >
                 {row.getVisibleCells().map((cell, idx) => (
-                    <TableCell
+                  <TableCell
                     key={cell.id}
                     className={
-                        (idx === 0
+                      (idx === 0
                         ? "rounded-l-md bg-git-int-primary hover:bg-git-int-primary text-white text-1xl"
                         : idx === row.getVisibleCells().length - 1
                         ? "rounded-r-md bg-git-int-primary hover:bg-git-int-primary text-white"
-                        : "bg-git-int-primary hover:bg-git-int-primary text-white text-2xl font-bold") +
-                        " py-0"
+                        : "bg-git-int-primary hover:bg-git-int-primary text-white text-2xl font-bold") + //Final Grade is slightly larger and bolder than other text
+                      " py-0"
                     }
-                    >
-
+                  >
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                     {idx === row.getVisibleCells().length - 2 && "%"}
-                    </TableCell>
+                  </TableCell>
                 ))}
-                </TableRow>
+              </TableRow>
 
+              {/* Expanded Rows */}
               {row.getIsExpanded() && row.original.aliases?.length > 0 && (
                 <>
-                  
+                  {/* Row for Associated Accounts */}
                   <TableRow className="bg-git-bg-elevated hover:bg-git-bg-elevated text-white border-black">
                     <TableCell colSpan={columns.length}>
                       <span className="ml-4 font-medium text-gray-800">
@@ -89,16 +98,17 @@ export function DataTable<TData extends { aliases?: AliasEmail[] }, TValue>({
                     </TableCell>
                   </TableRow>
 
-                  
+                  {/* Rows for Aliases */}
                   {row.original.aliases.map((alias, idx) => (
                     <TableRow
-                    key={`${row.id}-alias-${idx}`}
-                    className="bg-git-bg-elevated hover:bg-git-bg-elevated border-style: dashed">
-                    <TableCell colSpan={columns.length}>
+                      key={`${row.id}-alias-${idx}`}
+                      className="bg-git-bg-elevated hover:bg-git-bg-elevated border-style: dashed"
+                    >
+                      <TableCell colSpan={columns.length}>
                         <div className="ml-8 text-sm text-gray-700">
-                        <strong>{alias.username}</strong> ({alias.email})
+                          <strong>{alias.username}</strong> ({alias.email})
                         </div>
-                    </TableCell>
+                      </TableCell>
                     </TableRow>
                   ))}
                 </>

--- a/commitment/imports/ui/components/scaling/ScalingTable.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingTable.tsx
@@ -50,7 +50,7 @@ export function DataTable<TData extends { aliases?: AliasEmail[] }, TValue>({
               {headerGroup.headers.map((header) => (
                 <TableHead
                   key={header.id}
-                  className="text-git-text-primary bg-git-int-secondary"
+                  className="text-git-text-primary bg-git-int-secondary hover:bg-git-int-secondary"
                 >
                   {header.isPlaceholder
                     ? null

--- a/commitment/imports/ui/components/scaling/ScalingTable.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingTable.tsx
@@ -39,41 +39,49 @@ export function DataTable<TData extends { aliases?: AliasEmail[] }, TValue>({
   });
 
   return (
-    <div className="overflow-hidden rounded-md border">
+    <div className="overflow-hidden rounded-md  bg-git-bg-elevated">
       <Table>
-        <TableHeader>
-          {table.getHeaderGroups().map((headerGroup) => (
+       <TableHeader>
+        {table.getHeaderGroups().map((headerGroup) => (
             <TableRow key={headerGroup.id}>
-              {headerGroup.headers.map((header) => (
-                <TableHead key={header.id}>
-
-                  {header.isPlaceholder
+            {headerGroup.headers.map((header) => (
+                <TableHead key={header.id} className="font-bold">
+                {header.isPlaceholder
                     ? null
                     : flexRender(header.column.columnDef.header, header.getContext())}
                 </TableHead>
-              ))}
+            ))}
             </TableRow>
-          ))}
+        ))}
         </TableHeader>
+
         <TableBody>
           {table.getRowModel().rows.map((row) => (
             <React.Fragment key={row.id}>
-                <TableRow
-                onClick={() => row.toggleExpanded()}
-                className="bg-git-int-primary hover:bg-git-int-primary text-white"
-                >
+                <TableRow onClick={() => row.toggleExpanded()} className="cursor-pointer">
+                {row.getVisibleCells().map((cell, idx) => (
+                    <TableCell
+                    key={cell.id}
+                    className={
+                        (idx === 0
+                        ? "rounded-l-md bg-git-int-primary hover:bg-git-int-primary text-white text-1xl"
+                        : idx === row.getVisibleCells().length - 1
+                        ? "rounded-r-md bg-git-int-primary hover:bg-git-int-primary text-white"
+                        : "bg-git-int-primary hover:bg-git-int-primary text-white text-2xl font-bold") +
+                        " py-0"
+                    }
+                    >
 
-                {row.getVisibleCells().map((cell) => (
-                  <TableCell key={cell.id} >
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </TableCell>
+                    {idx === row.getVisibleCells().length - 2 && "%"}
+                    </TableCell>
                 ))}
-              </TableRow>
+                </TableRow>
 
               {row.getIsExpanded() && row.original.aliases?.length > 0 && (
                 <>
                   
-                  <TableRow className="bg-gray-50 border-b-2 border-black">
+                  <TableRow className="bg-git-bg-elevated hover:bg-git-bg-elevated text-white border-black">
                     <TableCell colSpan={columns.length}>
                       <span className="ml-4 font-medium text-gray-800">
                         Associated Accounts
@@ -85,10 +93,10 @@ export function DataTable<TData extends { aliases?: AliasEmail[] }, TValue>({
                   {row.original.aliases.map((alias, idx) => (
                     <TableRow
                     key={`${row.id}-alias-${idx}`}
-                    className="bg-gray-50 border-style: dashed">
+                    className="bg-git-bg-elevated hover:bg-git-bg-elevated border-style: dashed">
                     <TableCell colSpan={columns.length}>
                         <div className="ml-8 text-sm text-gray-700">
-                            <strong>{alias.username}</strong> ({alias.email})
+                        <strong>{alias.username}</strong> ({alias.email})
                         </div>
                     </TableCell>
                     </TableRow>

--- a/commitment/imports/ui/components/scaling/ScalingView.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingView.tsx
@@ -15,67 +15,17 @@ import { GradingSheetForm } from "./GradingSheetForm";
 import ScalingSummary from "./ScalingSummary";
 import type { UserScalingSummary } from "@server/commitment_api/types";
 
-
 interface ScalingConfig {
   metrics: string[];
   method: string;
   customScript?: File[];
 }
 
-const userScalingSummaries: UserScalingSummary[] = [
-  {
-    name: "Jupyta Notebuk",
-    aliases: [
-      { username: "Bobert", email: "bobert@example.com" },
-      { username: "john", email: "john@example.com" },
-    ],
-    finalGrade: 78,
-    scale: 1,
-  },
-  {
-    name: "Poppy Willis",
-    aliases: [
-      { username: "capn america", email: "cap@example.com" },
-      { username: "iyan man", email: "iyan@example.com" },
-    ],
-    finalGrade: 42,
-    scale: 0.66,
-  },
-];
-
-
-
-function ThemeToggle() {
-  const [theme, setTheme] = useState(
-    localStorage.getItem("theme") || "light"
-  );
-
-  useEffect(() => {
-    if (theme === "dark") {
-      document.documentElement.classList.add("dark");
-    } else {
-      document.documentElement.classList.remove("dark");
-    }
-    localStorage.setItem("theme", theme);
-  }, [theme]);
-
-  return (
-    <button
-      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
-      className="p-2 border rounded"
-    >
-      {theme === "dark" ? "🌙 Dark" : "☀️ Light"}
-    </button>
-  );
-}
-
-
 function ScalingView() {
   const [completed, setCompleted] = useState(false);
   const [hasLoaded, setHasLoaded] = useState(false);
   const [step, setStep] = useState<"config" | "sheet" | "done">("config");
   const [showDialog, setShowDialog] = useState(false);
-  const [dialogClosedManually, setDialogClosedManually] = useState(false);
   const [config, setConfig] = useState<ScalingConfig | null>(null);
   const [gradingSheet, setGradingSheet] = useState<File | null>(null);
 
@@ -106,6 +56,9 @@ function ScalingView() {
     setStep("done");
   };
 
+  // This is the variable that must store the final grades, scalings, aliases and name of contributors
+  const userScalingSummaries: UserScalingSummary[] = [];
+
   return (
     <div className="m-0 scroll-smooth">
       <div className="flex flex-col gap-32">
@@ -124,7 +77,6 @@ function ScalingView() {
               Create New Scaling
             </Button>
           )}
-          <ThemeToggle/>
 
           {/* Show summary if completed */}
           {completed && config && gradingSheet && (
@@ -159,9 +111,6 @@ function ScalingView() {
             open={showDialog}
             onOpenChange={(open) => {
               setShowDialog(open);
-              if (!open) {
-                setDialogClosedManually(true); // track if user manually closed
-              }
             }}
           >
             <DialogHeader>

--- a/commitment/imports/ui/components/scaling/ScalingView.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingView.tsx
@@ -49,7 +49,7 @@ function ScalingView() {
     setStep('sheet');
   };
 
-  const handleSheetSubmit = (sheetFile: File) => {
+  const handleSheetSubmit = (sheetFile: File | null) => {
     setGradingSheet(sheetFile);
     setCompleted(true);
     setShowDialog(false);
@@ -61,31 +61,53 @@ function ScalingView() {
       <div className="flex flex-col gap-32">
         <div className="max-w-[1600px] mx-20 rounded-2xl bg-white p-8">
           
-        {hasLoaded && !completed && !showDialog && (
-        <Button
-            className="bg-git-int-primary text-git-int-text hover:bg-git-int-primary-hover"
-            onClick={() => {
-            setStep('config');
-            setShowDialog(true);
-            }}
-        >
-            Create New Scaling
-        </Button>
-        )}
+        {/* {hasLoaded && !completed && !showDialog && (
+       
+        )} */}
+        {!(completed && config && gradingSheet) && (
+  <Button
+    className="bg-git-int-primary text-git-int-text hover:bg-git-int-primary -hover"
+    onClick={() => {
+      setStep('config');
+      setShowDialog(true);
+    }}
+  >
+    Create New Scaling
+  </Button>
+)}
+
 
           {/* Show summary if completed */}
           {completed && config && gradingSheet && (
-           <ScalingSummary 
-                method={config.method} 
-                metrics={config.metrics.join(', ')} 
-                fileName={gradingSheet.name} 
-            />
-            // <div className="mt-8 p-4 border rounded-md bg-gray-50">
-            //   <h2 className="text-xl font-semibold mb-2">Scaling Summary</h2>
-            //   <p><strong>Method:</strong> {config.method}</p>
-            //   <p><strong>Metrics:</strong> {config.metrics.join(', ')}</p>
-            //   <p><strong>Grading Sheet:</strong> {gradingSheet.name}</p>
-            // </div>
+          <div>
+            <ScalingSummary 
+                    method={config.method} 
+                    metrics={config.metrics.join(', ')} 
+                    fileName={"TEST"} 
+                />
+
+            <div className="flex justify-center gap-6 p-4">
+                <Button
+                    className="bg-git-int-primary text-git-int-text hover:bg-git-int-primary-hover"
+                    onClick={() => {
+                    setStep('sheet');
+                    setShowDialog(true);
+                    }}
+                >
+                    Upload Grading Sheet
+                </Button>
+                <Button
+                    className="bg-git-int-primary text-git-int-text hover:bg-git-int-primary-hover"
+                    onClick={() => {
+                    setStep('config');
+                    setShowDialog(true);
+                    }}
+                >
+                    Generate New Scaling
+                </Button>
+            </div>          
+          </div>
+
           )}
 
           {/* Multi-Step Dialog */}

--- a/commitment/imports/ui/components/scaling/ScalingView.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingView.tsx
@@ -61,16 +61,17 @@ function ScalingView() {
       <div className="flex flex-col gap-32">
         <div className="max-w-[1600px] mx-20 rounded-2xl bg-white p-8">
           
-          {/* Show button only if: loaded, not completed, and dialog is not open */}
-          <Button
-              className="bg-git-int-primary text-git-int-text hover:bg-git-int-primary-hover"
-              onClick={() => {
-                setStep('config');
-                setShowDialog(true);
-              }}
-            >
-              Create New Scaling
-            </Button>
+        {hasLoaded && !completed && !showDialog && (
+        <Button
+            className="bg-git-int-primary text-git-int-text hover:bg-git-int-primary-hover"
+            onClick={() => {
+            setStep('config');
+            setShowDialog(true);
+            }}
+        >
+            Create New Scaling
+        </Button>
+        )}
 
           {/* Show summary if completed */}
           {completed && config && gradingSheet && (

--- a/commitment/imports/ui/components/scaling/ScalingView.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingView.tsx
@@ -13,18 +13,8 @@ import {
 import { Button } from "../ui/button";
 import { GradingSheetForm } from "./GradingSheetForm";
 import ScalingSummary from "./ScalingSummary";
+import type { UserScalingSummary } from "@server/commitment_api/types";
 
-export type AliasEmail = {
-  username: string;
-  email: string;
-};
-
-export type UserScalingSummary = {
-  name: string;
-  aliases: AliasEmail[];
-  finalGrade: number;
-  scale: number;
-};
 
 interface ScalingConfig {
   metrics: string[];
@@ -52,6 +42,33 @@ const userScalingSummaries: UserScalingSummary[] = [
     scale: 0.66,
   },
 ];
+
+
+
+function ThemeToggle() {
+  const [theme, setTheme] = useState(
+    localStorage.getItem("theme") || "light"
+  );
+
+  useEffect(() => {
+    if (theme === "dark") {
+      document.documentElement.classList.add("dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+    }
+    localStorage.setItem("theme", theme);
+  }, [theme]);
+
+  return (
+    <button
+      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+      className="p-2 border rounded"
+    >
+      {theme === "dark" ? "🌙 Dark" : "☀️ Light"}
+    </button>
+  );
+}
+
 
 function ScalingView() {
   const [completed, setCompleted] = useState(false);
@@ -107,6 +124,7 @@ function ScalingView() {
               Create New Scaling
             </Button>
           )}
+          <ThemeToggle/>
 
           {/* Show summary if completed */}
           {completed && config && gradingSheet && (

--- a/commitment/imports/ui/components/scaling/ScalingView.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingView.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import React, { useState, useEffect } from 'react';
 import ScalingConfigForm from './ScalingConfigForm';
 import {
@@ -10,6 +12,7 @@ import {
 
 import { Button } from '../ui/button';
 import { GradingSheetForm } from './GradingSheetForm';
+import ScalingSummary from './ScalingSummary';
 
 interface ScalingConfig {
   metrics: string[];
@@ -71,12 +74,17 @@ function ScalingView() {
 
           {/* Show summary if completed */}
           {completed && config && gradingSheet && (
-            <div className="mt-8 p-4 border rounded-md bg-gray-50">
-              <h2 className="text-xl font-semibold mb-2">Scaling Summary</h2>
-              <p><strong>Method:</strong> {config.method}</p>
-              <p><strong>Metrics:</strong> {config.metrics.join(', ')}</p>
-              <p><strong>Grading Sheet:</strong> {gradingSheet.name}</p>
-            </div>
+           <ScalingSummary 
+                method={config.method} 
+                metrics={config.metrics.join(', ')} 
+                fileName={gradingSheet.name} 
+            />
+            // <div className="mt-8 p-4 border rounded-md bg-gray-50">
+            //   <h2 className="text-xl font-semibold mb-2">Scaling Summary</h2>
+            //   <p><strong>Method:</strong> {config.method}</p>
+            //   <p><strong>Metrics:</strong> {config.metrics.join(', ')}</p>
+            //   <p><strong>Grading Sheet:</strong> {gradingSheet.name}</p>
+            // </div>
           )}
 
           {/* Multi-Step Dialog */}

--- a/commitment/imports/ui/components/scaling/ScalingView.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingView.tsx
@@ -1,18 +1,30 @@
-"use client"
+"use client";
 
-import React, { useState, useEffect } from 'react';
-import ScalingConfigForm from './ScalingConfigForm';
+import React, { useState, useEffect } from "react";
+import ScalingConfigForm from "./ScalingConfigForm";
 import {
   Dialog,
   DialogContent,
   DialogDescription,
   DialogHeader,
   DialogTitle,
-} from '../ui/dialog';
+} from "../ui/dialog";
 
-import { Button } from '../ui/button';
-import { GradingSheetForm } from './GradingSheetForm';
-import ScalingSummary from './ScalingSummary';
+import { Button } from "../ui/button";
+import { GradingSheetForm } from "./GradingSheetForm";
+import ScalingSummary from "./ScalingSummary";
+
+export type AliasEmail = {
+  username: string;
+  email: string;
+};
+
+export type UserScalingSummary = {
+  name: string;
+  aliases: AliasEmail[];
+  finalGrade: number;
+  scale: number;
+};
 
 interface ScalingConfig {
   metrics: string[];
@@ -20,10 +32,31 @@ interface ScalingConfig {
   customScript?: File[];
 }
 
+const userScalingSummaries: UserScalingSummary[] = [
+  {
+    name: "Jupyta Notebuk",
+    aliases: [
+      { username: "Bobert", email: "bobert@example.com" },
+      { username: "john", email: "john@example.com" },
+    ],
+    finalGrade: 78,
+    scale: 1,
+  },
+  {
+    name: "Poppy Willis",
+    aliases: [
+      { username: "capn america", email: "cap@example.com" },
+      { username: "iyan man", email: "iyan@example.com" },
+    ],
+    finalGrade: 42,
+    scale: 0.66,
+  },
+];
+
 function ScalingView() {
   const [completed, setCompleted] = useState(false);
   const [hasLoaded, setHasLoaded] = useState(false);
-  const [step, setStep] = useState<'config' | 'sheet' | 'done'>('config');
+  const [step, setStep] = useState<"config" | "sheet" | "done">("config");
   const [showDialog, setShowDialog] = useState(false);
   const [dialogClosedManually, setDialogClosedManually] = useState(false);
   const [config, setConfig] = useState<ScalingConfig | null>(null);
@@ -31,7 +64,7 @@ function ScalingView() {
 
   // Load from localStorage on first mount
   useEffect(() => {
-    const lsCompleted = localStorage.getItem('hasVisitedScaling') === 'true';
+    const lsCompleted = localStorage.getItem("hasVisitedScaling") === "true";
     setCompleted(lsCompleted);
     if (!lsCompleted) setShowDialog(true);
     setHasLoaded(true);
@@ -40,74 +73,67 @@ function ScalingView() {
   // Persist to localStorage
   useEffect(() => {
     if (hasLoaded) {
-      localStorage.setItem('hasVisitedScaling', completed ? 'true' : 'false');
+      localStorage.setItem("hasVisitedScaling", completed ? "true" : "false");
     }
   }, [completed, hasLoaded]);
 
   const handleConfigSubmit = (configData: ScalingConfig) => {
     setConfig(configData);
-    setStep('sheet');
+    setStep("sheet");
   };
 
   const handleSheetSubmit = (sheetFile: File | null) => {
     setGradingSheet(sheetFile);
     setCompleted(true);
     setShowDialog(false);
-    setStep('done');
+    setStep("done");
   };
 
   return (
     <div className="m-0 scroll-smooth">
       <div className="flex flex-col gap-32">
         <div className="max-w-[1600px] mx-20 rounded-2xl bg-white p-8">
-          
-        {/* {hasLoaded && !completed && !showDialog && (
+          {/* {hasLoaded && !completed && !showDialog && (
        
         )} */}
-        {!(completed && config && gradingSheet) && (
-  <Button
-    className="bg-git-int-primary text-git-int-text hover:bg-git-int-primary -hover"
-    onClick={() => {
-      setStep('config');
-      setShowDialog(true);
-    }}
-  >
-    Create New Scaling
-  </Button>
-)}
-
+          {!(completed && config && gradingSheet) && (
+            <Button
+              className="bg-git-int-primary text-git-int-text hover:bg-git-int-primary -hover"
+              onClick={() => {
+                setStep("config");
+                setShowDialog(true);
+              }}
+            >
+              Create New Scaling
+            </Button>
+          )}
 
           {/* Show summary if completed */}
           {completed && config && gradingSheet && (
-          <div>
-            <ScalingSummary 
-                    method={config.method} 
-                    metrics={config.metrics.join(', ')} 
-                    fileName={"TEST"} 
-                />
+            <div>
+              <ScalingSummary userScalingSummaries={userScalingSummaries} />
 
-            <div className="flex justify-center gap-6 p-4">
+              <div className="flex justify-center gap-6 p-4">
                 <Button
-                    className="bg-git-int-primary text-git-int-text hover:bg-git-int-primary-hover"
-                    onClick={() => {
-                    setStep('sheet');
+                  className="bg-git-int-primary text-git-int-text hover:bg-git-int-primary-hover"
+                  onClick={() => {
+                    setStep("sheet");
                     setShowDialog(true);
-                    }}
+                  }}
                 >
-                    Upload Grading Sheet
+                  Upload Grading Sheet
                 </Button>
                 <Button
-                    className="bg-git-int-primary text-git-int-text hover:bg-git-int-primary-hover"
-                    onClick={() => {
-                    setStep('config');
+                  className="bg-git-int-primary text-git-int-text hover:bg-git-int-primary-hover"
+                  onClick={() => {
+                    setStep("config");
                     setShowDialog(true);
-                    }}
+                  }}
                 >
-                    Generate New Scaling
+                  Generate New Scaling
                 </Button>
-            </div>          
-          </div>
-
+              </div>
+            </div>
           )}
 
           {/* Multi-Step Dialog */}
@@ -125,10 +151,10 @@ function ScalingView() {
               <DialogDescription />
             </DialogHeader>
             <DialogContent className="max-w-full">
-              {step === 'config' && (
+              {step === "config" && (
                 <ScalingConfigForm onSubmit={handleConfigSubmit} />
               )}
-              {step === 'sheet' && (
+              {step === "sheet" && (
                 <GradingSheetForm onSubmit={handleSheetSubmit} />
               )}
             </DialogContent>

--- a/commitment/imports/ui/components/ui/table.tsx
+++ b/commitment/imports/ui/components/ui/table.tsx
@@ -1,0 +1,114 @@
+import * as React from "react"
+
+import { cn } from "@ui/lib/utils"
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  )
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "bg-muted/50 border-t font-medium [&>tr]:last:border-b-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("text-muted-foreground mt-4 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/commitment/package-lock.json
+++ b/commitment/package-lock.json
@@ -24,6 +24,7 @@
         "@radix-ui/react-tabs": "^1.1.12",
         "@radix-ui/react-toast": "^1.2.13",
         "@radix-ui/react-toggle": "^1.1.6",
+        "@tanstack/react-table": "^8.21.3",
         "class-variance-authority": "^0.7.1",
         "classnames": "^2.5.1",
         "clsx": "^2.1.1",
@@ -2732,6 +2733,39 @@
         "@tailwindcss/oxide": "4.1.11",
         "postcss": "^8.4.41",
         "tailwindcss": "4.1.11"
+      }
+    },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/table-core": "8.21.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/commitment/package.json
+++ b/commitment/package.json
@@ -29,6 +29,7 @@
     "@radix-ui/react-tabs": "^1.1.12",
     "@radix-ui/react-toast": "^1.2.13",
     "@radix-ui/react-toggle": "^1.1.6",
+    "@tanstack/react-table": "^8.21.3",
     "class-variance-authority": "^0.7.1",
     "classnames": "^2.5.1",
     "clsx": "^2.1.1",

--- a/commitment/server/commitment_api/types.ts
+++ b/commitment/server/commitment_api/types.ts
@@ -112,3 +112,15 @@ export const getTypeBy = (c: string): ChangeType | null => {
 };
 
 export const sortCommitByTimeStamp = (c1: CommitData, c2: CommitData): number => c2.timestamp.getTime() - c1.timestamp.getTime();
+
+export type AliasEmail = {
+  username: string;
+  email: string;
+};
+
+export type UserScalingSummary = {
+  name: string;
+  aliases: AliasEmail[];
+  finalGrade: number;
+  scale: number;
+};

--- a/commitment/server/commitment_api/types.ts
+++ b/commitment/server/commitment_api/types.ts
@@ -111,3 +111,4 @@ export const getTypeBy = (c: string): ChangeType | null => {
   }
 };
 
+export const sortCommitByTimeStamp = (c1: CommitData, c2: CommitData): number => c2.timestamp.getTime() - c1.timestamp.getTime();

--- a/commitment/server/commitment_api/types.ts
+++ b/commitment/server/commitment_api/types.ts
@@ -111,4 +111,3 @@ export const getTypeBy = (c: string): ChangeType | null => {
   }
 };
 
-export const sortCommitByTimeStamp = (c1: CommitData, c2: CommitData): number => c2.timestamp.getTime() - c1.timestamp.getTime();

--- a/commitment/tsconfig.json
+++ b/commitment/tsconfig.json
@@ -32,7 +32,8 @@
         "node_modules/@types/meteor/*",
         ".meteor/local/types/packages.d.ts"
       ],
-      "@ui/*": ["imports/ui/*"]
+      "@ui/*": ["imports/ui/*"],
+      "@server/*": ["server/*"]
     },
     "moduleResolution": "node",
     "resolveJsonModule": true,


### PR DESCRIPTION
## Implementation Details
- Created the **Scaling Output page**:  
  - Displays a table with contributor name, alias, scaled grade, and scaling factor (0–1). 
  - Each row can expand to show additional details. 
  - Added a radial chart to visualise scaling results.

---

## Steps to Test
1. Switch to the `feat/scaling-output-page` branch. 
2. Run the application locally.  
3. Go to localhost:port/metrics and click scaling
4. Create mock data in the 'userScalingSummaries' constant in line 60 of ScalingView.tsx (you can work out the structure from UserScalingSummary in types.ts)
5. Click Create new scaling and navigate through the 'generate scaling' and 'upload grading sheet' pop-ups. Afterwards you should see the developed table.
6. Verify: 
  - Table shows contributors, aliases, scaled grades, and scaling factors. 
  - Rows expand/collapse correctly.
  - Radial chart displays corresponding scaling visualisation. 
  - Colours match Figma design in both light and dark mode.  
  - Dark mode toggle (top right) works as expected.

---

## Screenshots
<img width="1664" height="753" alt="Screenshot 2025-08-14 at 6 57 01 pm" src="https://github.com/user-attachments/assets/d116d6d0-2b97-49e4-8aef-c2d9e31c6946" />
<img width="1664" height="753" alt="Screenshot 2025-08-14 at 6 57 30 pm" src="https://github.com/user-attachments/assets/4cd0b087-c579-4bf9-8fdd-73237e38636a" />

---

## Linked Issue/Story
https://app.clickup.com/t/86czv7wmx