### PR TITLE
Git API: Updating Types + UNIX Pipelines

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1,1 +1,3 @@
 # commitment-api
+
+# TODO

--- a/api/commitment-api.cabal
+++ b/api/commitment-api.cabal
@@ -45,7 +45,8 @@ executable commitment-api
       filepath,
       unix-compat,
       deepseq,
-      network
+      network,
+      regex-posix
   ghc-options:
       -Wall
       -Wcompat

--- a/api/commitment-api.cabal
+++ b/api/commitment-api.cabal
@@ -44,7 +44,8 @@ executable commitment-api
       directory,
       filepath,
       unix-compat,
-      deepseq
+      deepseq,
+      network
   ghc-options:
       -Wall
       -Wcompat

--- a/api/commitment-api.cabal
+++ b/api/commitment-api.cabal
@@ -29,7 +29,7 @@ executable commitment-api
       base >= 4.7 && < 5,
       wai,
       warp,
-      websockets,
+      websockets >= 0.13.0.0,
       wai-websockets,
       aeson,
       text,

--- a/api/src/Api.hs
+++ b/api/src/Api.hs
@@ -89,6 +89,7 @@ appWS pendingConn = do
           Right repoData -> sendTextData conn (BL.toStrict $ encodeValue "value" repoData)
           Left errmsg    -> do
             safePrint $ "Encountered error: " ++ errmsg
+            sendTextData conn (BL.toStrict $ encodeValue "text_update" errmsg)
             sendTextData conn (BL.toStrict $ encodeError (T.pack ("err: " ++ errmsg)))
 
       sendClose conn ("Done" :: Text)
@@ -119,7 +120,7 @@ fallback req respond =
                 respond $ responseLBS status200 [("Content-Type", "application/json")]
                           $ encodeValue "value" repoData
               Left errmsg -> do
-                safePrint $ "Encountered error: " ++ errmsg
+                safePrint $ "Encountered error:\n" ++ errmsg
                 respond $ responseLBS status500 [("Content-Type", "application/json")]
                           $ encodeError (T.pack ("err: " ++ errmsg))
 

--- a/api/src/Api.hs
+++ b/api/src/Api.hs
@@ -32,23 +32,25 @@ import Data.Text (Text)
 import Data.Char (isSpace)
 import GHC.Generics
 import qualified Data.ByteString.Lazy as BL
-import Data.ByteString.Lazy.Char8() 
+import qualified Data.ByteString as BS
+import Data.ByteString.Lazy.Char8()
 
 import Control.Concurrent.STM (atomically, newTBQueue, readTBQueue)
-import Control.Concurrent (forkIO)
+import Control.Concurrent.Async (withAsync)
 import Control.Monad (forever, void)
 
 import Commitment (fetchDataFrom)
 import Types ()
 import Threading (safePrint)
 
--- Incoming JSON from JS
+------------------------------------------------------------
+-- Incoming JSON
+------------------------------------------------------------
 data ClientMessage = ClientMessage { url :: String }
   deriving (Show, Generic)
 
 instance FromJSON ClientMessage
 
--- Outgoing structured response
 encodeValue :: ToJSON a => Text -> a -> BL.ByteString
 encodeValue label val = encode $ object ["type" .= label, "data" .= val]
 
@@ -65,13 +67,10 @@ trim = f . f
 appWS :: ServerApp
 appWS pendingConn = do
   conn <- acceptRequest pendingConn
-  --safePrint "WebSocket client connected"
 
-  -- Step 1: Wait for { "url": "..." } from client
   msg <- receiveData conn
   case eitherDecode (BL.fromStrict msg) of
-    Left err -> do
-      --safePrint $ "Invalid JSON: " ++ err
+    Left _ -> do
       sendTextData conn $ encodeError "Invalid JSON format. Expected: {\"url\": \"...\"}"
       sendClose conn ("Bad input" :: Text)
 
@@ -79,18 +78,18 @@ appWS pendingConn = do
       safePrint $ "Processing URL (WS): " ++ repoUrl
       notifier <- atomically $ newTBQueue 1000
 
-      -- Stream text_update messages
-      _ <- forkIO $ forever $ do
-        update <- atomically $ readTBQueue notifier
-        sendTextData conn $ BL.toStrict $ encodeValue "text_update" update
+      -- Stream text_update messages while job runs
+      withAsync (forever $ do
+          update <- atomically $ readTBQueue notifier
+          sendTextData conn (BL.toStrict $ encodeValue "text_update" update)
+        ) $ \_ -> do
 
-      -- Run the actual job
-      result <- fetchDataFrom (trim repoUrl) notifier
-      case result of
-        Right repoData -> sendTextData conn $ BL.toStrict $ encodeValue "value" repoData
-        Left errmsg    -> do
-          safePrint $ "Encountered error: " ++ errmsg
-          sendTextData conn $ BL.toStrict $ encodeError (T.pack ("err: " ++ errmsg))
+        result <- fetchDataFrom (trim repoUrl) notifier
+        case result of
+          Right repoData -> sendTextData conn (BL.toStrict $ encodeValue "value" repoData)
+          Left errmsg    -> do
+            safePrint $ "Encountered error: " ++ errmsg
+            sendTextData conn (BL.toStrict $ encodeError (T.pack ("err: " ++ errmsg)))
 
       sendClose conn ("Done" :: Text)
 
@@ -98,30 +97,34 @@ appWS pendingConn = do
 -- 🌐 HTTP Fallback Handler (POST only)
 ------------------------------------------------------------
 fallback :: Application
-fallback req respond = do
+fallback req respond =
   if requestMethod req /= methodPost
     then respond $ responseLBS status405 [("Content-Type", "text/plain")] "Method Not Allowed"
     else do
       body <- strictRequestBody req
       case eitherDecode body of
-        Left err -> respond $ responseLBS status400 [("Content-Type", "application/json")] $ encodeError "Invalid JSON format. Expected: {\"url\": \"...\"}"
+        Left _ ->
+          respond $ responseLBS status400 [("Content-Type", "application/json")]
+                    $ encodeError "Invalid JSON format. Expected: {\"url\": \"...\"}"
 
         Right (ClientMessage repoUrl) -> do
           safePrint $ "Processing URL (HTTP): " ++ repoUrl
           notifier <- atomically $ newTBQueue 1000
 
-          -- We discard updates for HTTP; could log or save
-          _ <- forkIO $ forever $ void (atomically (readTBQueue notifier))
+          -- Discard updates, but ensure worker cleaned up
+          withAsync (forever $ void (atomically (readTBQueue notifier))) $ \_ -> do
+            result <- fetchDataFrom (trim repoUrl) notifier
+            case result of
+              Right repoData ->
+                respond $ responseLBS status200 [("Content-Type", "application/json")]
+                          $ encodeValue "value" repoData
+              Left errmsg -> do
+                safePrint $ "Encountered error: " ++ errmsg
+                respond $ responseLBS status500 [("Content-Type", "application/json")]
+                          $ encodeError (T.pack ("err: " ++ errmsg))
 
-          result <- fetchDataFrom (trim repoUrl) notifier
-          case result of
-            Right repoData ->
-              respond $ responseLBS status200 [("Content-Type", "application/json")] $
-                encodeValue "value" repoData
-            Left errmsg -> do
-              safePrint $ "Encountered error: " ++ errmsg
-              respond $ responseLBS status500 [("Content-Type", "application/json")] $
-                encodeError (T.pack ("err: " ++ errmsg))
-
+------------------------------------------------------------
+-- Exported HTTP app
+------------------------------------------------------------
 appHTTP :: Application
 appHTTP = fallback

--- a/api/src/Command.hs
+++ b/api/src/Command.hs
@@ -33,6 +33,7 @@ import Threading
 
 data Command = Command
   { command    :: String
+  , env_vars   :: Maybe [(String, String)]
   , onSuccess  :: String -> String -> String
   , onFail     :: String -> String -> String
   , onStdFail  :: String -> String -> String -> String
@@ -60,7 +61,7 @@ defaultStdFail :: String -> String -> String -> String
 defaultStdFail c _ se = "Command:\n" ++ c ++ "\nError:\n" ++ se
 
 logData :: Command
-logData = Command "" defaultSuccess defaultFail defaultStdFail True
+logData = Command "" Nothing defaultSuccess defaultFail defaultStdFail True
 
 doNotLogData :: Command
 doNotLogData = logData { shouldLog = False }
@@ -76,6 +77,7 @@ executeCommand notifier filepath f = do
             { cwd = Just filepath
             , std_out = CreatePipe
             , std_err = CreatePipe
+            , env = env_vars f  -- include environment variables if they exist
             }
 
       (_, Just hout, Just herr, phandle) <- createProcess processSpec

--- a/api/src/Commitment.hs
+++ b/api/src/Commitment.hs
@@ -25,6 +25,7 @@ import System.FilePath
 import System.IO.Unsafe (unsafePerformIO)
 import System.Directory (getCurrentDirectory, createDirectoryIfMissing)
 import Control.Concurrent (getNumCapabilities)
+import Threading (safePrint)
 
 -- Create global thread pools
 {-# NOINLINE parsingPool #-}
@@ -75,10 +76,9 @@ fetchDataFrom url notifier = (do
         awaitCreateRepoDir   <- createDirectoryIfMissing True repoAbsPath
 
         emit notifier "Cloning repo..."
-        assertSuccess <- parsed "Failed to clone the repo" <$> await (submitTaskAsync commandPool
+        awaitCloneResult <- parsed "Failed to clone the repo" <$> await (submitTaskAsync commandPool
             (\path -> successful <$> executeCommand notifier workingDir (cloneRepo url path))
-            repoAbsPath
-            )
+            repoAbsPath) 
 
         emit notifier "Getting repository data..."
         repoData <- formulateRepoData url repoAbsPath notifier

--- a/api/src/GitCommands.hs
+++ b/api/src/GitCommands.hs
@@ -57,7 +57,7 @@ getCommitDetails hash = doNotLogData
 
 getCommitDiff :: String -> Command
 getCommitDiff hash = doNotLogData
-  { command = "git --no-pager diff-tree -p" ++ hash 
+  { command = "git --no-pager diff-tree -p " ++ hash 
   }
 
 getRepoName :: Command

--- a/api/src/GitCommands.hs
+++ b/api/src/GitCommands.hs
@@ -8,9 +8,6 @@ module GitCommands (
   getContributorEmails,
   getCommitDetails,
   getCommitDiff,
-  getFileContents,
-  getFileDataFromCommit,
-  getOldFileDataFromCommit,
   getRepoName
 ) where
 
@@ -60,7 +57,7 @@ getCommitDetails hash = doNotLogData
 
 getCommitDiff :: String -> Command
 getCommitDiff hash = doNotLogData
-  { command = "git --no-pager diff " ++ hash 
+  { command = "git --no-pager diff-tree -p" ++ hash 
   }
 
 getRepoName :: Command

--- a/api/src/GitCommands.hs
+++ b/api/src/GitCommands.hs
@@ -28,7 +28,8 @@ checkIfRepoExists url = doNotLogData
 
 cloneRepo :: String -> FilePath -> Command
 cloneRepo url targetDirectory = doNotLogData
-  { command = "git clone --no-checkout " ++ quote url ++ " " ++ quote targetDirectory
+  { command = "git clone --bare " ++ quote url ++ " " ++ quote targetDirectory
+  , env_vars = Just [("GIT_TERMINAL_PROMPT", "0")]
   , onSuccess = \_ _ -> url ++ " successfully cloned to " ++ targetDirectory
   , onFail = \c e -> "Error cloning repo:\nCommand:\n" ++ c ++ "\nError Message:\n" ++ e
   }

--- a/api/src/GitCommands.hs
+++ b/api/src/GitCommands.hs
@@ -7,6 +7,7 @@ module GitCommands (
   getAllCommitsFrom,
   getContributorEmails,
   getCommitDetails,
+  getCommitDiff,
   getFileContents,
   getFileDataFromCommit,
   getOldFileDataFromCommit,
@@ -57,18 +58,9 @@ getCommitDetails hash = doNotLogData
   { command = "git show \"--pretty=format:%H\\n|||END|||%an\\n|||END|||%ad\\n|||END|||%s\\n|||END|||%b\\n|||END|||\" \"--name-status\" " ++ hash 
   }
 
-getFileContents :: TBQueue String -> FilePath -> String -> (String -> String -> Command) -> String -> IO String
-getFileContents notifier path hash cmd_f file =
-  getParsableStringFromCmd <$> executeCommand notifier path (cmd_f hash file)
-
-getFileDataFromCommit :: String -> FilePath -> Command
-getFileDataFromCommit hash path = doNotLogData
-  { command = "git show " ++ hash ++ ":" ++ path
-  }
-
-getOldFileDataFromCommit :: String -> FilePath -> Command
-getOldFileDataFromCommit hash path = doNotLogData
-  { command = "git show " ++ hash ++ "~1:" ++ path
+getCommitDiff :: String -> Command
+getCommitDiff hash = doNotLogData
+  { command = "git --no-pager diff " ++ hash 
   }
 
 getRepoName :: Command

--- a/api/src/GitCommands.hs
+++ b/api/src/GitCommands.hs
@@ -28,8 +28,11 @@ checkIfRepoExists url = doNotLogData
 
 cloneRepo :: String -> FilePath -> Command
 cloneRepo url targetDirectory = doNotLogData
-  { command = "git clone --bare " ++ quote url ++ " " ++ quote targetDirectory
+  { command =
+      "git -c credential.helper= -c core.askPass=true clone --bare "
+      ++ quote url ++ " " ++ quote targetDirectory
   , env_vars = Just [("GIT_TERMINAL_PROMPT", "0")]
+  , env_clean = ["GIT_ASKPASS","GCM_INTERACTIVE"]
   , onSuccess = \_ _ -> url ++ " successfully cloned to " ++ targetDirectory
   , onFail = \c e -> "Error cloning repo:\nCommand:\n" ++ c ++ "\nError Message:\n" ++ e
   }

--- a/api/src/GitCommands.hs
+++ b/api/src/GitCommands.hs
@@ -39,7 +39,7 @@ cloneRepo url targetDirectory = doNotLogData
 
 getBranches :: Command
 getBranches = doNotLogData
-  { command = "git branch -a --format=" ++ quote "%(refname:short)"
+  { command = "git --no-pager branch -a --format=" ++ quote "%(refname:short)"
   }
 
 getAllCommitsFrom :: String -> Command

--- a/api/src/Main.hs
+++ b/api/src/Main.hs
@@ -3,12 +3,24 @@
 module Main (main) where
 
 import Api
+import Control.Concurrent (forkIO)
 
-import Network.Wai.Handler.Warp (runSettings, defaultSettings, setPort, setHost)
 import Network.Wai.Handler.WebSockets (websocketsOr)
 import Network.WebSockets (defaultConnectionOptions)
 
+import Network.Wai.Handler.Warp (runSettings, defaultSettings, setPort, setHost)
+import Network.Wai.Handler.Warp.Unix (runSettingsUnix, defaultUnixSettings, setUnixSocket)
+
 main :: IO ()
-main = runSettings settings $ websocketsOr defaultConnectionOptions appWS appHTTP
+main = do
+  let app = websocketsOr defaultConnectionOptions appWS appHTTP
+
+  -- Run TCP server on 0.0.0.0:8081
+  _ <- forkIO $ runSettings tcpSettings app
+
+  -- Run Unix socket server on /tmp/haskell-ipc.sock
+  runSettingsUnix unixSettings app
+
   where
-    settings = setPort 8081 $ setHost "0.0.0.0" defaultSettings
+    tcpSettings  = setPort 8081 $ setHost "0.0.0.0" defaultSettings
+    unixSettings = setUnixSocket "/tmp/haskell-ipc.sock" defaultUnixSettings

--- a/api/src/Main.hs
+++ b/api/src/Main.hs
@@ -4,23 +4,38 @@ module Main (main) where
 
 import Api
 import Control.Concurrent (forkIO)
+import Control.Exception (bracket)
 
 import Network.Wai.Handler.WebSockets (websocketsOr)
 import Network.WebSockets (defaultConnectionOptions)
 
-import Network.Wai.Handler.Warp (runSettings, defaultSettings, setPort, setHost)
-import Network.Wai.Handler.Warp.Unix (runSettingsUnix, defaultUnixSettings, setUnixSocket)
+import Network.Wai.Handler.Warp (runSettings, defaultSettings, setPort, setHost, Settings)
+import Network.Wai.Handler.Warp (runSettingsSocket)
+import Network.Socket
+  ( socket, bind, listen, Socket, SockAddr(SockAddrUnix)
+  , Family(AF_UNIX), SocketType(Stream)
+  , close
+  )
 
 main :: IO ()
 main = do
-  let app = websocketsOr defaultConnectionOptions appWS appHTTP
+    let app = websocketsOr defaultConnectionOptions appWS appHTTP
 
-  -- Run TCP server on 0.0.0.0:8081
-  _ <- forkIO $ runSettings tcpSettings app
+    -- Run TCP server on 0.0.0.0:8081
+    _ <- forkIO $ runSettings tcpSettings app
 
-  -- Run Unix socket server on /tmp/haskell-ipc.sock
-  runSettingsUnix unixSettings app
+    -- Run Unix domain socket server on /tmp/haskell-ipc.sock
+    bracket (setupUnixSocket "/tmp/haskell-ipc.sock") close $ \unixSock ->
+        runSettingsSocket defaultSettings unixSock app
 
-  where
-    tcpSettings  = setPort 8081 $ setHost "0.0.0.0" defaultSettings
-    unixSettings = setUnixSocket "/tmp/haskell-ipc.sock" defaultUnixSettings
+-- TCP Settings
+tcpSettings :: Settings
+tcpSettings = setPort 8081 $ setHost "0.0.0.0" defaultSettings
+
+-- Helper to create a Unix domain socket
+setupUnixSocket :: FilePath -> IO Socket
+setupUnixSocket path = do
+    sock <- socket AF_UNIX Stream 0
+    bind sock (SockAddrUnix path)
+    listen sock 1024
+    return sock

--- a/api/src/Main.hs
+++ b/api/src/Main.hs
@@ -26,11 +26,7 @@ import Network.Socket
 main :: IO ()
 main = do
     -- Enable permessage-deflate (RSV1 frames allowed)
-    #if defined(mingw32_HOST_OS)
     let opts = defaultConnectionOptions  -- no connectionCompression
-    #else
-    let opts = defaultConnectionOptions { connectionCompression = False }
-    #endif
     let app  = websocketsOr opts appWS appHTTP
 
 #if defined(mingw32_HOST_OS)

--- a/api/src/Parsing.hs
+++ b/api/src/Parsing.hs
@@ -18,8 +18,10 @@ module Parsing (
   MetaFileChanges(..),
   parseCommitData,
   parseFileDataFromCommit,
+  MetaFileChangesDiff(..),
   parseFileDataFromDiff,
   pairByFilePath,
+  mergeFileMetaData,
   lastElem
 ) where
 
@@ -30,12 +32,13 @@ import Data.Time (UTCTime)
 import Data.Time.Format (parseTimeM, defaultTimeLocale)
 import Control.Applicative (Alternative, empty, (<|>))
 import Text.Regex.Posix ((=~))
+import qualified Data.Map.Strict as Map
+import Data.Maybe (mapMaybe)
 
-import Threading
 import Types
 import Command
 
--- define a type for the parsing result for each of the parsers
+-- ParseResult
 data ParseResult a = Result a | Error String
   deriving (Show)
 
@@ -67,7 +70,6 @@ instance MonadFail ParseResult where
 instance Alternative ParseResult where
   empty :: ParseResult a
   empty = Error ""
-
   (<|>) :: ParseResult a -> ParseResult a -> ParseResult a
   (<|>) (Result a) _ = Result a
   (<|>) _ (Result b) = Result b
@@ -80,7 +82,8 @@ maybeToResult msg Nothing = Error msg
 successful :: CommandResult -> ParseResult String
 successful (CommandResult _   (Just err) (Just stdErr)) = Error $ err ++ ":\n" ++ stdErr
 successful (CommandResult _   (Just err) _            ) = Error err
-successful (CommandResult res _          (Just stdErr)) = if failedOutput stdErr || failedOutput res then Error stdErr else Result res
+successful (CommandResult res _          (Just stdErr)) =
+  if failedOutput stdErr || failedOutput res then Error stdErr else Result res
 successful (CommandResult res _          _            ) = Result res
 
 parsed :: String -> ParseResult a -> a
@@ -88,6 +91,7 @@ parsed _ (Result r)   = r
 parsed "" (Error "")  = error "Got blank string"
 parsed "" (Error msg) = error msg
 parsed msg (Error e)  = error $ msg ++ ":\n" ++ e
+--                    = error $ msg ++ ":\n" ++ e
 
 parsedLists :: String -> [ParseResult a] -> [a]
 parsedLists msg = map (parsed msg)
@@ -95,61 +99,68 @@ parsedLists msg = map (parsed msg)
 parsedNestedLists :: String -> [[ParseResult a]] -> [[a]]
 parsedNestedLists msg = map (parsedLists msg)
 
--- | Returns true if the output indicates a failed command
+-- Failure detector
 failedOutput :: String -> Bool
-failedOutput txt = any (`isPrefixOf` txt) [
-    "fatal:" 
-    , "error:" 
-    , "could not" 
-    , "not a git repository" 
-    , "Process exited with code" 
-    , "Encountered error"
-    , "Process timed out"
+failedOutput txt = any (`isPrefixOf` txt)
+  [ "fatal:"
+  , "error:"
+  , "could not"
+  , "not a git repository"
+  , "Process exited with code"
+  , "Encountered error"
+  , "Process timed out"
   ]
 
--- | Safely extract exact text from command output
 exactText :: String -> ParseResult String
 exactText txt = if failedOutput txt then Error txt else Result txt
 
 parseRepoExists :: String -> ParseResult String
 parseRepoExists txt = if failedOutput txt then Error txt else Result "repo exists"
 
--- | Parses the remote URL into the repo name
+-- Repo name from URL
 parseRepoName :: String -> ParseResult String
 parseRepoName txt
   | failedOutput txt = Error txt
-  | otherwise = maybeToResult "Inside parseRepoName failed to get lastElem" . lastElem . split '/' . clean . trim $ txt
+  | otherwise        = maybeToResult "Inside parseRepoName failed to get lastElem"
+                    . lastElem
+                    . split '/'
+                    . clean
+                    . trim
+                    $ txt
   where
     trim = dropWhileEnd isSpace . dropWhile isSpace
     clean t = if ".git" `isSuffixOf` t then take (length t - 4) t else t
 
--- | Remove duplicates from contributor emails
+-- Emails
 parseContributorEmails :: String -> ParseResult [String]
 parseContributorEmails txt
   | failedOutput txt = Error txt
-  | otherwise = Result . nub . lines $ txt
+  | otherwise        = Result . nub . lines $ txt
 
+-- Branches
 parseRepoBranches :: String -> ParseResult [String]
 parseRepoBranches txt
   | failedOutput txt = Error txt
-  | otherwise = Result . filter (not . null)
-                    . map (stripPrefixStar . trim)
-                    . filter (not . ("->" `isInfixOf`))
-                    . lines $ txt
+  | otherwise        = Result
+    . filter (not . null)
+    . map (stripPrefixStar . trim)
+    . filter (not . ("->" `isInfixOf`))
+    . lines
+    $ txt
   where
     trim = dropWhileEnd isSpace . dropWhile isSpace
     stripPrefixStar ('*':' ':rest) = rest
-    stripPrefixStar x = x
+    stripPrefixStar x              = x
 
+-- Commit hashes
 parseCommitHashes :: String -> ParseResult [String]
 parseCommitHashes txt
   | failedOutput txt = Error txt
-  | otherwise = Result . filter (not . null) . filter validLine . lines $ txt
+  | otherwise        = Result . filter (not . null) . filter validLine . lines $ txt
   where
     validLine l = not ("The system cannot find the path specified." `isPrefixOf` l)
 
--- | Commit metadata parsed from stdout
-
+-- Commit metadata
 data InbetweenCommitData = InbetweenCommitData
   { ibCommitHash      :: String
   , ibCommitTitle     :: String
@@ -161,7 +172,7 @@ data InbetweenCommitData = InbetweenCommitData
 
 parseCommitData :: String -> ParseResult InbetweenCommitData
 parseCommitData txt
-  | failedOutput txt = Error txt
+  | failedOutput txt  = Error txt
   | length blocks < 6 = Error ("has less than 6 blocks: \"" ++ show blocks ++ "\" | txt: \"" ++ txt ++ "\"")
   | otherwise = do
       ts <- parseTimeM True defaultTimeLocale "%a %b %-d %T %Y %z" (trim $ blocks !! 2)
@@ -174,96 +185,127 @@ parseCommitData txt
         , involvedFiles     = parseFileLines (drop 5 blocks)
         }
   where
-    delim = "\\n|||END|||"
+    delim  = "\\n|||END|||"
     blocks = splitOn delim txt
-    trim = intercalate "\n" . map (dropWhile isSpace) . lines
+    trim   = intercalate "\n" . map (dropWhile isSpace) . lines
 
 parseFileLines :: [String] -> [[String]]
 parseFileLines = map words . filter (not . null) . lines . unlines
 
+-- Name-status record
 data MetaFileChanges = MetaFileChanges
   { filepathM    :: String
   , oldFilePathM :: String
   , charM        :: ChangeType
   , likenessM    :: Int
-  }
+  } deriving (Show, Eq)
 
+-- Parse a single name-status line (split into words)
 parseFileDataFromCommit :: [String] -> ParseResult MetaFileChanges
-parseFileDataFromCommit dataList = do
+parseFileDataFromCommit dataList =
   case dataList of
     (changeStr:rest) -> do
+      -- first char is status (A,M,D,R,C), remainder may be percentage for R/C (e.g. "R100")
       let (changeChar:likenessStr) = changeStr
+      changeTy <- maybeToResult ("Invalid change type: " ++ [changeChar]) (getChangeType changeChar)
 
       newFilePathTxt <- maybeToResult "Missing new file path" (lastElem rest)
-      changeType <- maybeToResult ("Invalid change type: " ++ [changeChar]) (getChangeType changeChar)
-      oldFilePathT <- case rest of 
-        (oldFilePathTxt:_) | changeChar `elem` ['R', 'C', 'M'] -> pure oldFilePathTxt
-        _                                                     -> newFilePath
-      likenessInt <- case rest of 
-        (oldFilePathTxt:_) | changeChar `elem` ['R', 'C'] -> do
-          let cleanedLikeliness = filter (/= ',') likenessStr
-          case readMaybe cleanLikeness of 
-            Just likelinessInt -> pure likelinessInt
-            Nothing            -> pure -1
 
-      pure $ MetaFileChanges (
-          filepathM    newFilePathT
-          oldFilePathM oldFilePathT
-          charM        changeChar 
-          likenessM    likenessInt
-        )
+      let oldFilePathTxt =
+            case rest of
+              (oldFP:_) | changeChar `elem` ['R','C','M'] -> oldFP
+              _                                            -> newFilePathTxt
 
+          likenessInt =
+            case rest of
+              (_:_) | changeChar `elem` ['R','C'] ->
+                let cleaned = filter (/= ',') likenessStr
+                in maybe (-1) id (readMaybe cleaned :: Maybe Int)
+              _ -> -1
+
+      pure MetaFileChanges
+        { filepathM    = newFilePathTxt
+        , oldFilePathM = oldFilePathTxt
+        , charM        = changeTy
+        , likenessM    = likenessInt
+        }
     _ -> Error $ "Malformed dataList: " ++ show dataList
 
+-- Diff record
 data MetaFileChangesDiff = MetaFileChangesDiff
   { filepathMD     :: String
   , diffMD         :: [String]
   , newLinesMD     :: Int
   , deletedLinesMD :: Int
-  }
+  } deriving (Show, Eq)
 
+-- Parse a full `git show -p` (or `git diff`) text into per-file diffs
 parseFileDataFromDiff :: String -> ParseResult [MetaFileChangesDiff]
 parseFileDataFromDiff txt
   | failedOutput txt = Error txt
-  | length blocks < 5 = Error ("has less than 5 blocks: \"" ++ show blocks ++ "\" | txt: \"" ++ txt ++ "\"")
-  | otherwise = do
-      let (header, fileTxt) = splitAt 5 blocks 
-      return MetaFileChangesDiff
-        { filepathMD   = extractFilePath blocks !! 0
-        , newLines     = countLinesWithPrefix "+" fileTxt
-        , deletedLines = countLinesWithPrefix "-" fileTxt
-        , diffMD       = fileTxt
-        }
+  | otherwise        = Result (finalize (reverse acc))
   where
-    delim = "\n"
-    blocks = splitOn delim txt
-    trim = intercalate "\n" . map (dropWhile isSpace) . lines
-    extractFilePath line =
-      case line =~ "^diff --git a/.+ b/(.+)$" :: [[String]] of
+    ls = lines txt
+
+    -- group into file blocks starting at "diff --git ..."
+    (acc, curHdr, curBody) = foldl step ([], Nothing, []) ls
+
+    step :: ([ (String,[String]) ], Maybe String, [String]) -> String -> ([ (String,[String]) ], Maybe String, [String])
+    step (blocks, mHdr, body) line
+      | "diff --git " `isPrefixOf` line =
+          let blocks' = case mHdr of
+                          Just h  -> (h, reverse body) : blocks
+                          Nothing -> blocks
+          in (blocks', Just line, [])
+      | otherwise = (blocks, mHdr, line:body)
+
+    finalize :: [ (String,[String]) ] -> [MetaFileChangesDiff]
+    finalize blocks =
+      [ let fp = maybe "<unknown>" id (extractFilePath hdr)
+            adds = countAdds body
+            dels = countDels body
+        in MetaFileChangesDiff
+              { filepathMD     = fp
+              , diffMD         = body
+              , newLinesMD     = adds
+              , deletedLinesMD = dels
+              }
+      | (hdr, body) <- blocks
+      ]
+
+    -- Extract b/<path> from the diff header
+    extractFilePath :: String -> Maybe String
+    extractFilePath header =
+      case header =~ "^diff --git a/.+ b/(.+)$" :: [[String]] of
         [[_, path]] -> Just path
         _           -> Nothing
-    countLinesWithPrefix delim lines =
-      length $ filter (isPrefixOf delim) lines
 
+    -- count + / - lines but ignore file headers like "+++" and "---"
+    countAdds :: [String] -> Int
+    countAdds = length . filter (\l -> "+"  `isPrefixOf` l && not ("+++" `isPrefixOf` l))
+
+    countDels :: [String] -> Int
+    countDels = length . filter (\l -> "-"  `isPrefixOf` l && not ("---" `isPrefixOf` l))
+
+-- Pair by new file path
 pairByFilePath :: [MetaFileChanges] -> [MetaFileChangesDiff] -> [(MetaFileChanges, MetaFileChangesDiff)]
 pairByFilePath infos diffs =
   let diffMap = Map.fromList [(filepathMD d, d) | d <- diffs]
   in mapMaybe (\i -> fmap (\d -> (i, d)) (Map.lookup (filepathM i) diffMap)) infos
 
-mergeFileMetaData :: [(MetaFileChanges, MetaFileChangesDiff)] -> FileChanges
+mergeFileMetaData :: [(MetaFileChanges, MetaFileChangesDiff)] -> [FileChanges]
 mergeFileMetaData = map (
-    \(changes, diffTxt) -> FileChanges (
-        filepathM       changes
-        oldFilePathM    changes  
-        charM           changes         
-        likenessM       changes     
-        newLinesMD      diffTxt
-        deletedLinesMD  diffTxt
-        diffMD          diffTxt
-    )
-  ) 
+    \(changes, diffTxt) -> FileChanges 
+        (filepathM       changes)
+        (oldFilePathM    changes)  
+        (charM           changes)         
+        (likenessM       changes)     
+        (newLinesMD      diffTxt)
+        (deletedLinesMD  diffTxt)
+        (diffMD          diffTxt)
+    ) 
 
--- Helper functions
+-- Helpers
 splitOn :: Eq a => [a] -> [a] -> [[a]]
 splitOn delim = go
   where
@@ -271,18 +313,16 @@ splitOn delim = go
       Just (before, after) -> before : go after
       Nothing              -> [s]
 
--- Breaks list on the first occurrence of a delimiter
 breakList :: Eq a => [a] -> [a] -> Maybe ([a], [a])
 breakList pat xs = case breakOn pat xs of
   Nothing -> Nothing
   Just (a, b) -> Just (a, drop (length pat) b)
 
--- Breaks list at first occurrence of a pattern
 breakOn :: Eq a => [a] -> [a] -> Maybe ([a], [a])
 breakOn _ [] = Nothing
 breakOn pat l@(x:xs)
   | pat `isPrefixOf` l = Just ([], l)
-  | otherwise = fmap (first (x:)) (breakOn pat xs)
+  | otherwise          = fmap (first (x:)) (breakOn pat xs)
 
 first :: (a -> b) -> (a, c) -> (b, c)
 first f (x, y) = (f x, y)
@@ -292,17 +332,15 @@ split delim = foldr f [[]]
   where
     f c acc@(x:xs)
       | c == delim = []:acc
-      | otherwise = (c:x):xs
+      | otherwise  = (c:x):xs
 
 isInfixOf :: Eq a => [a] -> [a] -> Bool
 isInfixOf needle haystack = any (needle `isPrefixOf`) (tails haystack)
 
--- | tails :: [a] -> [[a]]
 tails :: [a] -> [[a]]
-tails [] = [[]]
+tails []       = [[]]
 tails x@(_:xs) = x : tails xs
 
--- Simpler alternative to Data.List.last that returns Maybe
 lastElem :: [a] -> Maybe a
 lastElem [] = Nothing
 lastElem xs = Just (last xs)

--- a/api/src/Parsing.hs
+++ b/api/src/Parsing.hs
@@ -76,9 +76,9 @@ maybeToResult msg Nothing = Error msg
 
 successful :: CommandResult -> ParseResult String
 successful (CommandResult _   (Just err) (Just stdErr)) = Error $ err ++ ":\n" ++ stdErr
-successful (CommandResult _   (Just err) _)             = Error err
-successful (CommandResult res _ (Just stdErr))          = if failedOutput stdErr || failedOutput res then Error stdErr else Result res
-successful (CommandResult res _ _)                      = Result res
+successful (CommandResult _   (Just err) _            ) = Error err
+successful (CommandResult res _          (Just stdErr)) = if failedOutput stdErr || failedOutput res then Error stdErr else Result res
+successful (CommandResult res _          _            ) = Result res
 
 parsed :: String -> ParseResult a -> a
 parsed _ (Result r)   = r
@@ -94,7 +94,7 @@ parsedNestedLists msg = map (parsedLists msg)
 
 -- | Returns true if the output indicates a failed command
 failedOutput :: String -> Bool
-failedOutput txt = any (`isPrefixOf` txt) ["fatal:", "error:", "could not", "not a git repository", "Process exited with code"]
+failedOutput txt = any (`isPrefixOf` txt) ["fatal:", "error:", "could not", "not a git repository", "Process exited with code", "Encountered error"]
 
 -- | Safely extract exact text from command output
 exactText :: String -> ParseResult String

--- a/api/src/Parsing.hs
+++ b/api/src/Parsing.hs
@@ -77,7 +77,7 @@ maybeToResult msg Nothing = Error msg
 successful :: CommandResult -> ParseResult String
 successful (CommandResult _   (Just err) (Just stdErr)) = Error $ err ++ ":\n" ++ stdErr
 successful (CommandResult _   (Just err) _)             = Error err
-successful (CommandResult res _ (Just stdErr))          = if null res then Result stdErr else Result res
+successful (CommandResult res _ (Just stdErr))          = if failedOutput stdErr || failedOutput res then Error stdErr else Result res
 successful (CommandResult res _ _)                      = Result res
 
 parsed :: String -> ParseResult a -> a

--- a/api/src/Parsing.hs
+++ b/api/src/Parsing.hs
@@ -94,7 +94,15 @@ parsedNestedLists msg = map (parsedLists msg)
 
 -- | Returns true if the output indicates a failed command
 failedOutput :: String -> Bool
-failedOutput txt = any (`isPrefixOf` txt) ["fatal:", "error:", "could not", "not a git repository", "Process exited with code", "Encountered error"]
+failedOutput txt = any (`isPrefixOf` txt) [
+    "fatal:" 
+    , "error:" 
+    , "could not" 
+    , "not a git repository" 
+    , "Process exited with code" 
+    , "Encountered error"
+    , "Process timed out"
+  ]
 
 -- | Safely extract exact text from command output
 exactText :: String -> ParseResult String
@@ -179,15 +187,15 @@ extractCommitData getNew getOld filedata = do
       ("M":newFile:_) -> do
         newContents <- getNew newFile
         oldContents <- getOld newFile
-        return $ Result (newContents, oldContents, filedata)
+        return $ Result ("", "", filedata)
 
       ("D":oldFile:_) -> do
         oldContents <- getOld oldFile
-        return $ Result ("", oldContents, filedata)
+        return $ Result ("", "", filedata)
       
       (_:newFile:_) -> do
         newContents <- getNew newFile
-        return $ Result (newContents, "", filedata)
+        return $ Result ("", "", filedata)
 
       _ -> return $ Error $ "filedata not shaped correctly: " ++ show filedata
 

--- a/api/src/Types.hs
+++ b/api/src/Types.hs
@@ -8,7 +8,6 @@ module Types (
   CommitData(..),
   ContributorData(..),
   FileChanges(..),
-  FileContents(..),
   ChangeType(..),
   getChangeType,
   sortCommitsByTimestamp

--- a/api/src/Types.hs
+++ b/api/src/Types.hs
@@ -11,11 +11,6 @@ module Types (
   FileContents(..),
   ChangeType(..),
   getChangeType,
-  ChangeData(..),
-  ExtraData(..),
-  ModifyData(..),
-  RenameData(..),
-  CopyData(..),
   sortCommitsByTimestamp
 ) where
 
@@ -45,7 +40,6 @@ data CommitData = CommitData
   , description     :: String
   , timestamp       :: UTCTime
   , fileData        :: [FileChanges]
-  , diff            :: String
   } deriving (Show, Eq, Generic, ToJSON, FromJSON)
 
 data ContributorData = ContributorData
@@ -60,6 +54,7 @@ data FileChanges = FileChanges
   , likeness     :: Int
   , newLines     :: Int
   , deletedLines :: Int
+  , diff         :: [String]
   } deriving (Show, Eq, Generic, ToJSON, FromJSON)
 
 -- | Change types: A = Added, M = Modified, D = Deleted, R = Renamed, C = Copied

--- a/api/src/Types.hs
+++ b/api/src/Types.hs
@@ -45,21 +45,21 @@ data CommitData = CommitData
   , description     :: String
   , timestamp       :: UTCTime
   , fileData        :: [FileChanges]
+  , diff            :: String
   } deriving (Show, Eq, Generic, ToJSON, FromJSON)
-
+  
 data ContributorData = ContributorData
   { name :: String
   , emails           :: [String]
   } deriving (Show, Eq, Generic, ToJSON, FromJSON)
 
 data FileChanges = FileChanges
-  { file    :: FileContents
-  , changes :: ChangeData
-  } deriving (Show, Eq, Generic, ToJSON, FromJSON)
-
-data FileContents = FileContents
-  { filepath :: String
-  , contents :: String
+  { filepath     :: String
+  , newLines     :: Int
+  , deletedLines :: Int
+  , char         :: ChangeType
+  , oldFilePath  :: String
+  , likeness     :: Int
   } deriving (Show, Eq, Generic, ToJSON, FromJSON)
 
 -- | Change types: A = Added, M = Modified, D = Deleted, R = Renamed, C = Copied
@@ -73,45 +73,6 @@ getChangeType 'D' = Just D
 getChangeType 'R' = Just R
 getChangeType 'C' = Just C
 getChangeType  _  = Nothing
-
-data ChangeData = ChangeData
-  { char  :: ChangeType
-  , extra :: Maybe ExtraData
-  } deriving (Show, Eq, Generic, ToJSON, FromJSON)
-
-data ExtraData
-  = Modify ModifyData
-  | Rename RenameData
-  | Copy CopyData
-  deriving (Show, Eq, Generic)
-
-instance ToJSON ExtraData where
-  toJSON = genericToJSON defaultOptions { sumEncoding = UntaggedValue }
-
-instance FromJSON ExtraData where
-  parseJSON = genericParseJSON defaultOptions { sumEncoding = UntaggedValue }
-
-data ModifyData = ModifyData
-  { previousFile :: FileContents
-  } deriving (Show, Eq, Generic, ToJSON, FromJSON)
-
-data RenameData = RenameData
-  { oldFilePath :: String
-  , likeness    :: Int
-  } deriving (Show, Eq, Generic, ToJSON, FromJSON)
-
-data CopyData = CopyData
-  { copyOldFilePath :: String
-  , copyLikeness    :: Int
-  } deriving (Show, Eq, Generic, ToJSON, FromJSON)
-
--- | Monoid instance for FileContents (concatenates contents and uses longest path)
-instance Semigroup FileContents where
-  FileContents c1 p1 <> FileContents c2 p2 =
-    FileContents (c1 <> c2) (if length p1 >= length p2 then p1 else p2)
-
-instance Monoid FileContents where
-  mempty = FileContents "" ""
 
 -- | Sorting function (newest first)
 sortCommitsByTimestamp :: CommitData -> CommitData -> Ordering

--- a/api/src/Types.hs
+++ b/api/src/Types.hs
@@ -47,7 +47,7 @@ data CommitData = CommitData
   , fileData        :: [FileChanges]
   , diff            :: String
   } deriving (Show, Eq, Generic, ToJSON, FromJSON)
-  
+
 data ContributorData = ContributorData
   { name :: String
   , emails           :: [String]
@@ -55,11 +55,11 @@ data ContributorData = ContributorData
 
 data FileChanges = FileChanges
   { filepath     :: String
+  , oldFilePath  :: String
+  , char         :: ChangeType
+  , likeness     :: Int
   , newLines     :: Int
   , deletedLines :: Int
-  , char         :: ChangeType
-  , oldFilePath  :: String
-  , likeness     :: Int
   } deriving (Show, Eq, Generic, ToJSON, FromJSON)
 
 -- | Change types: A = Added, M = Modified, D = Deleted, R = Renamed, C = Copied

--- a/api/stack.yaml
+++ b/api/stack.yaml
@@ -8,7 +8,7 @@
 # A snapshot resolver dictates the compiler version and the set of packages
 # to be used for project dependencies. For example:
 #
-# snapshot: lts-22.28
+# snapshot: lts-24.0
 # snapshot: nightly-2024-07-05
 # snapshot: ghc-9.6.6
 #
@@ -30,12 +30,13 @@ snapshot:
 #   - auto-update
 #   - wai
 packages:
-- .
+  - .
 # Dependency packages to be pulled from upstream that are not in the snapshot.
 # These entries can reference officially published versions as well as
 # forks / in-progress versions pinned to a git hash. For example:
 #
-# extra-deps:
+extra-deps:
+  - websockets-0.13.0.0@sha256:9b3680ba5055e0b34ab29c341b21d70084bf067519fc059af0e597cd90a4a05a,7567
 # - acme-missiles-0.3
 # - git: https://github.com/commercialhaskell/stack.git
 #   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a

--- a/api/stack.yaml.lock
+++ b/api/stack.yaml.lock
@@ -3,7 +3,14 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: websockets-0.13.0.0@sha256:9b3680ba5055e0b34ab29c341b21d70084bf067519fc059af0e597cd90a4a05a,7567
+    pantry-tree:
+      sha256: 5f1ab27ecaf9c6fcabe5d86fb6fa55d79c8c506a216a0d088a60436643ec9f07
+      size: 2736
+  original:
+    hackage: websockets-0.13.0.0@sha256:9b3680ba5055e0b34ab29c341b21d70084bf067519fc059af0e597cd90a4a05a,7567
 snapshots:
 - completed:
     sha256: a3501d1b61a539371d85305fe73e1134fc08e7c97498a42952455f011fd97ecf

--- a/commitment/imports/api/types.ts
+++ b/commitment/imports/api/types.ts
@@ -45,25 +45,16 @@ export type ContributorData = Readonly<{
 }>;
 
 export type FileChanges = Readonly<{
-  file: FileContents;
-  changes: ChangeData;
-}>;
-
-export type FileContents = Readonly<{
-  contents: string;
-  filepath: string;
-}>;
-
-export type ChangeData = Readonly<{
-  char: ChangeType;
-  extra: null | ModifyData | RenameData | CopyData;
+  filepath: string    
+  oldFilePath: string 
+  char: ChangeType        
+  likeness: number    
+  newLines: number    
+  deletedLines: number
+  diff: [string]        
 }>;
 
 export type ChangeType = "A" | "M" | "D" | "R" | "C";
-// create diff section and greatly improve efficiency of storage by hashing FileContents so no repeated information is stashed in the DB
-export type ModifyData = Readonly<{ previousFile: FileContents }>;
-export type RenameData = Readonly<{ oldFilePath: string; likeness: number }>;
-export type CopyData = Readonly<{ oldFilePath: string; copyLikeness: number }>;
 
 export type AliasEmail = {
   username: string;


### PR DESCRIPTION
# Pull Request Title
## High-Level Description

Changes the "FileChanges" data structure + Unix pipelines

This was done by overhauling the old structure which captured the entire file contents, but now this version works on a git diff, which is significantly faster and more data efficient. 

Now all file changes work by having the diff of the file for that particular commit stored as lines, and optional parameters are now manditory, such as likeness, where now it is -1 by default and only a particular number if it is in git

The UNIX pipelines are only deployed when it is in a UNIX enviornment, so it is still able to work on Windows. When the API is deployed using Docker it will setup a UNIX .sock for the server to privately connect to, bypassing the network layer alltogether, increasing bandwidth between the API and the server. 

---

## Purpose of the Change

The amount of information was overwhelming the database, so doing this cuts out a significant amount of data storage
It also allows for more custom analytics, and for the better implementation of AI analytics as well.

UNIX pipelines are implemented for eventual performance

---

## Implementation Details

Types changes inside types.ts (meteor)
Types changes inside Types.hs
Parser changes inside Parsers.hs
Logic flow blocks inside Commitment.hs
Error catching mechanisms inside Threading.hs

---

## Steps to Test (if applicable)

Usual tests for calling the API (expect the data to have changed)

---

## Screenshots (if applicable)


---

## Linked Issue/Story

I did this pro bono baby
