### PR TITLE
fix: fixed formatting by adding the missing space after welcome back …

### DIFF
--- a/commitment/imports/ui/views/InsertGitRepoView/InsertGitRepo.tsx
+++ b/commitment/imports/ui/views/InsertGitRepoView/InsertGitRepo.tsx
@@ -17,8 +17,7 @@ const InsertGitRepoView: React.FC = () => {
       {isLoggedIn ? (
         <div className="flex flex-col items-center pt-20">
           <h1 className="text-6xl text-gray-700 mb-8">
-            Welcome Back,
-            {user?.profile?.name || 'User'}
+            Welcome Back, {user?.profile?.name || 'User'}
           </h1>
           <GitRepoInputSection />
           <LastSavedRepos />


### PR DESCRIPTION
# Pull Request Title
## High-Level Description

fixed the formatting on the insert git repo page by adding the missing space following 'welcome back' message. the change was made to align with basic typing and grammar syntax.

## Implementation Details

just added a space bar after welcome back message

## Steps to Test (if applicable)

go to insert git repo page as a logged in user and check if you see message that has a space bar after welcome back, as shown below. 
<img width="2235" height="983" alt="Screenshot 2025-09-04 at 10 46 28 PM" src="https://github.com/user-attachments/assets/c966b3a6-755c-42d1-b41f-f5b1adca90f9" />

## Linked Issue/Story

_Link to the relevant ClickUp task or issue. Example: [CU-abc123](https://app.clickup.com/t/abc123)_
