### PR TITLE
Fix/improved git repo input and alias config UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ NODE_ENV=development
 These provide steps to run the project.
 
 1. In the root directory of the project start the container with `docker-compose start`.
-2. Once it has started enter the `3170-env` container using `docker exec -it 3170-env bash`, this should take you into the `\commitment` directory.
+2. Once it has started enter the `3170-build` container using `docker exec -it 3170-build bash`, this should take you into the `\commitment` directory.
 3. Run `npm install` to install required dependencies, this may take some time.
 4. Run `meteor` to run the application.
    - This will be mapped to your `localhost` on `PORT 3000`.
@@ -95,7 +95,7 @@ These commands are useful for working with the container but must be run from th
 | ---------------------------- | ---------------------------------- |
 | Start Container              | `docker-compose start`             |
 | Stop Container               | `docker-compose stop`              |
-| Access Dev Container         | `docker exec -it 3170-env bash`    |
+| Access Dev Container         | `docker exec -it 3170-build bash`    |
 | Access Haskell Container     | `docker exec -it haskell-api bash` |
 | Attach Container to Terminal | `docker attach <container>`        |
 

--- a/commitment/imports/ui/components/insert-git-repo/GitRepoInputSection.tsx
+++ b/commitment/imports/ui/components/insert-git-repo/GitRepoInputSection.tsx
@@ -226,7 +226,7 @@ function GitRepoInputSection() {
       <div className="relative w-full max-w-lg mb-4">
         <Input
           type="text"
-          placeholder="Insert Git repository URL (GitHub, GitLab, Bitbucket)"
+          placeholder="Insert repository URL (GitHub, GitLab, Bitbucket)"
           className={cn(
             'w-full bg-git-bg-elevated/50 px-4 py-2 border shadow-xs focus:outline-hidden',
             validationError ? 'border-red-500 focus:ring-red-500 focus:border-red-500' : 'border-git-int-primary focus:ring-git-int-primary focus:border-git-int-primary',

--- a/commitment/imports/ui/components/metrics-page/TopBar.tsx
+++ b/commitment/imports/ui/components/metrics-page/TopBar.tsx
@@ -1,8 +1,6 @@
 import React, {  useEffect , useState } from 'react';
-import { Settings } from 'lucide-react';
 import { Meteor } from 'meteor/meteor';
 import { useLocation } from 'react-router-dom';
-import { AnalyticsData, Metadata } from '/imports/api/types';
 import BookmarkButton from '../dashboard/BookmarkButton';
 
 /**
@@ -55,7 +53,6 @@ export default function TopBar() {
           <BookmarkButton url={repoUrl} title={repoName} variant="secondary" />
         )}
       </div>
-      <Settings className="w-5 h-5 text-git-stroke-secondary hover:text-git-stroke-primary cursor-pointer" />
     </div>
   );
 }

--- a/commitment/imports/ui/components/settings/SettingsPage.tsx
+++ b/commitment/imports/ui/components/settings/SettingsPage.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useRef } from 'react';
-import NavBar from '@ui/components/landing-page/NavBar';
 import { Meteor } from 'meteor/meteor';
 import { useTracker } from 'meteor/react-meteor-data';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@ui/components/ui/tabs';
@@ -312,9 +311,7 @@ export const SettingsPage: React.FC = () => {
 
   return (
     <div className="min-h-screen bg-git-bg-primary">
-      <NavBar isLoggedIn={isLoggedIn} />
-      
-      <div className="max-w-6xl mx-auto px-6 py-8 pt-24">
+      <div className="max-w-6xl mx-auto px-6 py-8">
         <h1 className="text-4xl font-bold text-git-text-primary mb-4">
           Settings
         </h1>

--- a/commitment/imports/ui/components/settings/SettingsPage.tsx
+++ b/commitment/imports/ui/components/settings/SettingsPage.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useRef } from 'react';
 import { Meteor } from 'meteor/meteor';
 import { useTracker } from 'meteor/react-meteor-data';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@ui/components/ui/tabs';
 import { Button } from '@ui/components/ui/button';
 import { Upload, Info, FileText, X, CheckCircle, AlertCircle, Download, Play } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
@@ -11,7 +10,6 @@ export const SettingsPage: React.FC = () => {
   const isLoggedIn = !!user;
   const navigate = useNavigate();
   
-  const [activeTab, setActiveTab] = useState('profile');
   
   // File upload state
   const [isDragOver, setIsDragOver] = useState(false);
@@ -313,78 +311,27 @@ export const SettingsPage: React.FC = () => {
     <div className="min-h-screen bg-git-bg-primary">
       <div className="max-w-6xl mx-auto px-6 py-8">
         <h1 className="text-4xl font-bold text-git-text-primary mb-4">
-          Settings
+          Alias Configuration
         </h1>
         <p className="text-git-text-secondary text-lg mb-8">
-          This is the settings page.
+          Manage student alias mappings to consolidate contributions across multiple Git identities.
         </p>
 
-        {/* This is the tab system using same styling as MetricsTab */}
-        <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full bg-[#FEFEFA] shadow-sm justify-items-start">
-          {/* This creates the tab buttons at the top - same styling as MetricsTab */}
-          <TabsList className="flex bg-[#FEFEFA] border-b">
-            <TabsTrigger 
-              value="profile" 
-              className={`
-                relative px-4 text-lg font-medium text-gray-600
-                bg-[#FEFEFA] hover:bg-[#D0D0B7]
-                data-[state=active]:bg-gray-100
-                data-[state=active]:text-gray-900
-                data-[state=active]:after:content-['']
-                data-[state=active]:after:absolute
-                data-[state=active]:after:bottom-0
-                data-[state=active]:after:left-0
-                data-[state=active]:after:w-full
-                data-[state=active]:after:h-0.5
-                data-[state=active]:after:bg-git
-                rounded-none border-none shadow-none focus:outline-hidden
-                transition-all
-              `}
-            >
-              Profile
-            </TabsTrigger>
-            <TabsTrigger 
-              value="alias-config" 
-              className={`
-                relative px-4 text-lg font-medium text-gray-600
-                bg-[#FEFEFA] hover:bg-[#D0D0B7]
-                data-[state=active]:bg-gray-100
-                data-[state=active]:text-gray-900
-                data-[state=active]:after:content-['']
-                data-[state=active]:after:absolute
-                data-[state=active]:after:bottom-0
-                data-[state=active]:after:left-0
-                data-[state=active]:after:w-full
-                data-[state=active]:after:h-0.5
-                data-[state=active]:after:bg-git
-                rounded-none border-none shadow-none focus:outline-hidden
-                transition-all
-              `}
-            >
-              Alias Configuration
-            </TabsTrigger>
-          </TabsList>
-
-          {/* This is the content for the Profile tab */}
-          <TabsContent value="profile" className="mt-6">
-            <div className="p-6 bg-git-bg-elevated border border-git-stroke-primary rounded-lg">
-              <h2 className="text-2xl font-semibold text-git-text-primary mb-4">Profile Settings</h2>
-              <p className="text-git-text-secondary">Profile settings will go here!</p>
-            </div>
-          </TabsContent>
-
-          {/* This is the content for the Alias Configuration tab */}
-          <TabsContent value="alias-config" className="mt-6">
+        {/* Alias Configuration Section */}
+        <div className="space-y-6">
             {/* Current Config Section */}
             <div className="p-6 bg-git-bg-elevated border border-git-stroke-primary rounded-lg mb-6">
               <div className="mb-4">
                 <div className="flex items-center gap-2 mb-2">
                   <h2 className="text-2xl font-semibold text-git-text-primary">Your Alias Configuration</h2>
-                  <Info className="h-5 w-5 text-git-text-secondary" />
+                  <div className="relative group">
+                    <Info className="h-5 w-5 text-git-text-secondary cursor-help" />
+                    <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-3 py-2 bg-gray-900 text-white text-sm rounded-lg opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none whitespace-nowrap z-10">
+                      You can have one universal config file that applies to all repositories you analyse.
+                      <div className="absolute top-full left-1/2 transform -translate-x-1/2 border-4 border-transparent border-t-gray-900"></div>
+                    </div>
+                  </div>
                 </div>
-                <p className="text-git-text-secondary">
-                  You can have one universal config file that applies to all repositories you analyse.
-                </p>
               </div>
 
               {isLoadingConfigs ? (
@@ -398,9 +345,6 @@ export const SettingsPage: React.FC = () => {
                     <FileText className="h-8 w-8 text-git-text-secondary" />
                   </div>
                   <h3 className="text-lg font-medium text-git-text-primary mb-2">No Configuration Set</h3>
-                  <p className="text-git-text-secondary mb-4">
-                    Upload a config file to map multiple Git accounts to single students.
-                  </p>
                 </div>
               ) : (
                 <div className="space-y-4">
@@ -480,14 +424,14 @@ export const SettingsPage: React.FC = () => {
                   <h2 className="text-2xl font-semibold text-git-text-primary">
                     {currentConfigs.length > 0 ? 'Replace Configuration' : 'Upload Configuration'}
                   </h2>
-                  <Info className="h-5 w-5 text-git-text-secondary" />
+                  <div className="relative group">
+                    <Info className="h-5 w-5 text-git-text-secondary cursor-help" />
+                    <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-3 py-2 bg-gray-900 text-white text-sm rounded-lg opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none whitespace-nowrap z-10">
+                      Upload a config file to map multiple Git accounts to single students.
+                      <div className="absolute top-full left-1/2 transform -translate-x-1/2 border-4 border-transparent border-t-gray-900"></div>
+                    </div>
+                  </div>
                 </div>
-                <p className="text-git-text-secondary">
-                  {currentConfigs.length > 0 
-                    ? 'Upload a new config file to replace your current configuration.'
-                    : 'Upload a config file to map multiple Git accounts to single students.'
-                  }
-                </p>
                 {currentConfigs.length > 0 && (
                   <div className="mt-2 p-3 bg-yellow-50 border border-yellow-200 rounded-lg">
                     <p className="text-sm text-yellow-800">
@@ -622,11 +566,6 @@ export const SettingsPage: React.FC = () => {
                     <p className="text-git-text-secondary mb-2">
                       <strong>Students:</strong> {parsedAliases?.aliases?.length || 0}
                     </p>
-                    <p className="text-git-text-secondary">
-                      <strong>Total Aliases:</strong> {parsedAliases?.aliases?.reduce((acc: number, alias: any) => 
-                        acc + (alias.gitUsernames?.length || 0) + (alias.emails?.length || 0), 0
-                      ) || 0}
-                    </p>
                   </div>
                   <div className="flex gap-3">
                     <Button 
@@ -676,8 +615,7 @@ export const SettingsPage: React.FC = () => {
                 </p>
               </div>
             </div>
-          </TabsContent>
-        </Tabs>
+        </div>
       </div>
     </div>
   );

--- a/commitment/imports/ui/components/ui/profile-menu.tsx
+++ b/commitment/imports/ui/components/ui/profile-menu.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from "react";
-import { HelpCircle, LogOut, User, ChevronDown, Settings } from "lucide-react";
+import { HelpCircle, LogOut, User, ChevronDown, Users } from "lucide-react";
 import { Button } from "./button";
 import { Separator } from "./separator";
 import { useNavigate } from "react-router-dom";
@@ -59,8 +59,8 @@ export const ProfileMenu: React.FC<ProfileMenuProps> = ({
               onClick={handleSettingsClick}
               className="flex items-center gap-2 w-full px-4 py-2 text-sm text-foreground hover:bg-gray-100"
             >
-              <Settings className="h-4 w-4" />
-              <span>Settings</span>
+              <Users className="h-4 w-4" />
+              <span>Alias Configuration</span>
             </button>
 
             <Separator />

--- a/commitment/imports/ui/views/InsertGitRepoView/InsertGitRepo.tsx
+++ b/commitment/imports/ui/views/InsertGitRepoView/InsertGitRepo.tsx
@@ -15,8 +15,7 @@ const InsertGitRepoView: React.FC = () => {
       {isLoggedIn ? (
         <div className="flex flex-col items-center pt-20">
           <h1 className="text-6xl text-foreground mb-8">
-            Welcome Back,
-            {user?.profile?.name || "User"}
+            Welcome Back, {user?.profile?.name || "User"}
           </h1>
           <GitRepoInputSection />
           <LastSavedRepos />

--- a/commitment/server/methods.ts
+++ b/commitment/server/methods.ts
@@ -12,19 +12,37 @@ import {
   Selections,
   AllMetricsData,
   MetricType,
-  RepositoryData,
 } from "../imports/api/types";
-
-import { getContributors } from "./helper_functions";
 
 import { getAllGraphData, getAllMetricsFromData } from "./repo_metrics";
 import { applyAliasMappingIfNeeded } from "./alias_mapping";
-import { getRepoData } from "./fetch_repo";
-import { deserializeRepoData, serializeRepoData } from "../imports/api/serialisation";
 import { getScaledResults } from "./ScalingFunctions";
 import { ScalingConfig } from "/imports/ui/components/scaling/ScalingConfigForm";
+import { spawn } from "child_process";
 
 Meteor.methods({
+  /**
+   * Check if a repository exists and is accessible
+   * @param repoUrl The repository URL to check
+   * @returns Promise<boolean> True if repository exists and is accessible
+   */
+  async "repo.checkExists"(repoUrl: string): Promise<boolean> {
+    return new Promise((resolve) => {
+      const git = spawn('git', ['ls-remote', repoUrl], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: { ...process.env, GIT_TERMINAL_PROMPT: '0' }
+      });
+      
+      git.on('close', (code) => {
+        resolve(code === 0);
+      });
+      
+      git.on('error', () => {
+        resolve(false);
+      });
+    });
+  },
+
   /**
    * Get filtered repository data from the server
    * @param params.daysBack Number of days to look back (default: 7)


### PR DESCRIPTION
# Pull Request Title
## High-Level Description
This PR enhances the Git repository input validation for multiple platforms (GitHub, gitlab, bitbucket) and repository existence validation. while at it, I also improving the Alias Configuration page (previously settings page) UI with cleaner design and better user experience.

---

## Purpose of the Change

_Problems:_
- Problem 1: old code only had validation testing for GitHub repos, and gave errors for valid gitlab and bitbucket repos. URL validation was too restrictive and users received confusing error messages when trying to analyse non-GitHub repos
- Problem 2: when users entered an invalid repo, that is technically in the correct format but does not exist (may happen because of typos (e.g., https://gitlab.com/fake-account/no-such-repo-exists.git), users received generic "Error: Internal server error [500]" and then be directed back insert repo page eventually after timeout.  but there was no early validation to catch invalid repositories before processing. the long wait times (20 seconds) before redirecting users back is not the best user experience. 
- Problem 3: redundant profile section in settings page
I refactored the page as the profile section is not needed in upcoming milestone requirements, and having it increased the number of clicks users needed to access alias configuration. I also fixed double nav bar bug while at it. I renamed settings page to alias configuration (in the nabber --> profile section too) to make the feature easier to find and more intuitive. 
- Problem 4: Small ui bugs
redundancy settings icon in metrics page, missing space in "welcome back, user" message. updated README to use "3170-build" instead of old "3170-env" container name.

_how the change was implemented:_

- Multi platform git repo validation: my approach includes automatically detecting which platform user is using (GitHub, gitlab or bitbucket). then I use platform specific regex to verify if the input is valid, for example, for bitbucket specifically, because it has that username section in the link (since you have to login to view repos) it has the optional username section in its regex pattern.
- Validate if repo exists early on before going to loading page and receiving " Internal server error [500]": I added a server method "repo.checkExists" that uses  git ls-remote repo existence before proceeding. it gives a clear "Repository not found or not accessible" error right away. it is good because of immediate feedback. 
- alias config UI page: refactored the page. removed profile section. added necessary hover messages on info buttons for more intuitive user experience. fixed double nav bar bug. other minor UIs include removal of redundant settings icon. 

---

## Steps to Test (if applicable)

For repository validation, test:
GitHub valid repo: https://github.com/AmyTjea/test_repo_for_3170.git
Github invalid repo but looks valid: https://github.com/FakeAmyTjea/fake-test_repo_for_3170.git
Github completely invalid repo: www.happycow.com, gibberish.gibberish

GitLab valid repo: https://gitlab.com/kaarthika-group/oauth.git
GitLab invalid repo but looks valid: https://gitlab.com/not-kaarthika-group/not-oauth.git
GitLab completely invalid repo: https://kimetsu-no-yaiba.fandom.com/wiki/Kimetsu_no_Yaiba_Wiki

Bitbucket valid repo: to access it, you have to go [here](https://bitbucket.org/vdo_core/manual_data_prep_2025/src/main/), login and then click clone and copy the https link. 

<img width="2224" height="561" alt="Screenshot 2025-09-17 at 7 15 57 PM" src="https://github.com/user-attachments/assets/a714250f-4913-45c2-b178-e1a359790c30" />
e.g., https://ishratk1123@bitbucket.org/vdo_core/manual_data_prep_2025.git

Bitbucket invalid repo but looks valid: https://ishratk1123@bitbucket.org/fakevdo_core/fake_manual_data_prep_2025.git
Bitbucket completely invalid repo: https://optical.toys

---

## Screenshots (if applicable)

completely invalid links:
<img width="1216" height="309" alt="Screenshot 2025-09-17 at 7 17 56 PM" src="https://github.com/user-attachments/assets/4b82fc73-8d2a-4460-b048-87e8c60ad96b" />

invalid links that look valid:
<img width="2214" height="685" alt="Screenshot 2025-09-17 at 7 21 38 PM" src="https://github.com/user-attachments/assets/1e037093-9cd0-4281-a932-34ccb83589d4" />

valid links:
should take you to metrics. also ensure you don't see a settings icon in the top left corner of this page anymore. 
<img width="2232" height="1038" alt="Screenshot 2025-09-17 at 7 20 25 PM" src="https://github.com/user-attachments/assets/b07947dc-9a69-496e-9d93-38f24af844a9" />

settings page, new UI, check normal functions of adding, removing config file work well :D
<img width="2236" height="1069" alt="Screenshot 2025-09-17 at 7 22 44 PM" src="https://github.com/user-attachments/assets/605f479f-3f38-47a6-904f-fc87897478bd" />

---
## Linked Issue/Story

_Link to the relevant ClickUp task or issue. Example: [CU-abc123](https://app.clickup.com/t/abc123)_
