### PR TITLE
Fix: Bookmark loading from dashboard

### DIFF
--- a/commitment/imports/ui/components/metrics-page/TopBar.tsx
+++ b/commitment/imports/ui/components/metrics-page/TopBar.tsx
@@ -4,6 +4,7 @@ import { Meteor } from 'meteor/meteor';
 import { useLocation } from 'react-router-dom';
 import { AnalyticsData, Metadata } from '/imports/api/types';
 import BookmarkButton from '../dashboard/BookmarkButton';
+import { useAuth } from '../../hooks/useAuth';
 
 /**
  * JANKY METHOD FOR NOW taken from chatgpt: Extracts the repository name from a Git URL
@@ -26,6 +27,7 @@ function getRepoNameFromUrl(url: string): string {
 
 export default function TopBar() {
   // call meteor method to find the name
+  const signedIn = useAuth()
   const location = useLocation();
   const repoUrl: string | null = location.state?.repoUrl ?? null;
   const [repoName, setRepoName] = useState<string>("Loading...");
@@ -50,8 +52,8 @@ export default function TopBar() {
     <div className="flex items-center justify-between px-10 py-3 border-b  border-git-stroke-primary/40 bg-git-bg-elevated">
       <div className="flex items-center gap-3">
         <h2 className="text-lg font-semibold text-gray-800">{repoName}</h2>
-        {/* Bookmark button */}
-        {repoUrl && (
+        {/* Bookmark button (only shown to signed in users) */}
+        {(repoUrl && signedIn) && (
           <BookmarkButton url={repoUrl} title={repoName} variant="secondary" />
         )}
       </div>

--- a/commitment/imports/ui/views/DashboardView/DashboardView.tsx
+++ b/commitment/imports/ui/views/DashboardView/DashboardView.tsx
@@ -12,6 +12,7 @@ import { Button } from "@ui/components/ui/button";
 import { Bookmark } from "/imports/api/bookmarks";
 import { Meteor } from "meteor/meteor";
 import { useTracker } from "meteor/react-meteor-data";
+import { useNavigate } from "react-router-dom";
 import ViewToggle from "../../components/dashboard/ViewToggle";
 import RepoRow from "../../components/dashboard/RepoRow";
 import { FiltersState, FilterValue } from "../../components/ui/filter";
@@ -26,8 +27,6 @@ import { Input } from "../../components/ui/input";
 //   userID:"1"
 // }));
 
-const handleView = () => console.log("view metrics");
-
 type SortKey = "createdAt" | "lastViewed" | null;
 type SortDir = "asc" | "desc" | null;
 
@@ -38,6 +37,7 @@ const DashboardView: React.FC = () => {
   const [sortDir, setSortDir] = useState<SortDir>(null);
   const user = useTracker(() => Meteor.user());
   const userName = user?.profile?.name || user?.username || "User";
+  const navigate = useNavigate();
 
   const [filters, setFilters] = useState<FiltersState>({
     createdAt: { isUsed: false, value: { from: undefined, to: undefined } },
@@ -134,6 +134,19 @@ const DashboardView: React.FC = () => {
 
   const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
     updateFilter("titleSearch", e.target.value);
+  };
+
+  const handleViewRepository = (bookmark: Bookmark) => {
+    // Update lastViewed timestamp
+    Meteor.call("bookmarks.updateLastViewed", bookmark.url, (error: any) => {
+      if (error) {
+        console.error("Error updating lastViewed:", error);
+      }
+    });
+
+    navigate("/metrics", {
+      state: { repoUrl: bookmark.url }
+    });
   };
 
   useEffect(() => {
@@ -247,14 +260,14 @@ const DashboardView: React.FC = () => {
           // Gallery
           <div className="flex flex-wrap justify-evenly gap-10">
             {displayed.map((b) => (
-              <GalleryCard bookmark={b} onclick={handleView} />
+              <GalleryCard key={b._id} bookmark={b} onclick={() => handleViewRepository(b)} />
             ))}
           </div>
         ) : (
           // List
           <ul className="space-y-5">
             {displayed.map((b) => (
-              <RepoRow bookmark={b} onclick={handleView} />
+              <RepoRow key={b._id} bookmark={b} onclick={() => handleViewRepository(b)} />
             ))}
           </ul>
         )}


### PR DESCRIPTION
# Fix: Bookmark loading from dashboard
## High-Level Description

View repository button on dashboard should now actually open the bookmarked repo

---

## Purpose of the Change

Fixes broken dashboard gallery cards and repo row/listings.

---

## Implementation Details

Added a handle view repository function that redirects to metrics and opens the repo via the cached repo.
Additionaly, bookmark icon is hidden from users who are not signed in
---

## Steps to Test (if applicable)

1. Navigate to dashboard after bookmarking a repository
2. Click view repository
3. Should redirect you to the metrics page of the relevant repository

---

## Screenshots (if applicable)
Click the view repo button on a repository
<img width="1871" height="919" alt="image" src="https://github.com/user-attachments/assets/0553c3e7-3f29-4f4d-92a4-3e0633c65618" />


unsigned in view of the metrics page (no bookmark)
<img width="1901" height="818" alt="image" src="https://github.com/user-attachments/assets/b699e3d7-84dd-4ee0-b3be-d33bba630a92" />


signed in view of the metrics page (yes bookmark)

<img width="1910" height="635" alt="image" src="https://github.com/user-attachments/assets/17ed3227-2654-483a-9b73-bb024b119ac8" />


---