### PR TITLE
Fix/contributor filtering

### DIFF
--- a/commitment/imports/ui/components/metrics-page/AnalyticsView.tsx
+++ b/commitment/imports/ui/components/metrics-page/AnalyticsView.tsx
@@ -70,7 +70,7 @@ export function AnalyticsView(): React.JSX.Element {
           setError(err.message);
         } else {
           setAnalyticsData(data);
-          setSelectedContributors(data.metadata.contributors);
+          setSelectedContributors(data.metadata.contributors); // default to all contributors
           setSelectedBranch(data.selections.selectedBranch);
           setDateRange(data.selections.selectedDateRange);
         }

--- a/commitment/imports/ui/components/metrics-page/AnalyticsView.tsx
+++ b/commitment/imports/ui/components/metrics-page/AnalyticsView.tsx
@@ -70,7 +70,7 @@ export function AnalyticsView(): React.JSX.Element {
           setError(err.message);
         } else {
           setAnalyticsData(data);
-          setSelectedContributors(data.selections.selectedContributors);
+          setSelectedContributors(data.metadata.contributors);
           setSelectedBranch(data.selections.selectedBranch);
           setDateRange(data.selections.selectedDateRange);
         }

--- a/commitment/server/methods.ts
+++ b/commitment/server/methods.ts
@@ -138,8 +138,7 @@ Meteor.methods({
           : metadata.branches.includes("master")
           ? "master"
           : metadata.branches[0]),
-      selectedContributors:
-        !contributors || contributors.length === 0 ? metadata.contributors : contributors,
+      selectedContributors: contributors ?? [],
       selectedMetrics: metric,
       selectedDateRange: {
         from: startDate || metadata.dateRange.from,


### PR DESCRIPTION
# Bug Fix: Contributor Filtering 
## High-Level Description
This pull request updates how contributors are selected and displayed in the analytics view. The main change is to ensure that, by default, all contributors are shown when loading analytics data, and that the selected contributors state is handled more consistently across the client and server.

## Purpose of the Change
To address the bug where when a user selects no contributors, the metrics page was defaulting to show all contributor data. 

## Implementation Details
* In `AnalyticsView.tsx`, the default value for `selectedContributors` is now set to `data.metadata.contributors`, ensuring that all contributors are shown by default when analytics data is loaded.
* In `methods.ts`, the server now sets `selectedContributors` to an empty array if no contributors are provided, instead of defaulting to all contributors. This makes contributor selection more explicit and predictable.

## Steps to Test (if applicable)
1. Open up http://localhost:3000 and use [test repo](https://github.com/AmyTjea/test_repo_for_3170). 
2. Enter the metrics page and you should see that the default is "All Contributors" in the contributor drop down. Verify with Image 1. 
3. Select "Unselect All" in the contributor drop down. Verify with Image 2 - no data should be presented. 




## Screenshots (if applicable)

Image 1: 
<img width="1438" height="821" alt="image" src="https://github.com/user-attachments/assets/d36e9e8e-3881-4221-8a0a-6dc0b8c6d99e" />

Image 2: 
<img width="1443" height="810" alt="image" src="https://github.com/user-attachments/assets/a5250f89-d49b-409e-80da-5bde5df00a1b" />

## Linked Issue/Story
https://app.clickup.com/t/86d09vk4q
