### PR TITLE
Fix for alias issue

### DIFF
--- a/commitment/server/methods.ts
+++ b/commitment/server/methods.ts
@@ -241,6 +241,7 @@ export const getAnalyticsData = async ({
     endDate: selections.selectedDateRange.to!,
     branch: selections.selectedBranch,
     contributor: selections.selectedContributors,
+    userId,
   });
 
   const metricsData: MetricsData = await getAllGraphData(filteredRepo, metric);


### PR DESCRIPTION
# Fix graphs not showing some users after inputting alias config
## High-Level Description

Fix for issue https://github.com/Monash-FIT3170/2025W2-Commitment/issues/116

---

## Purpose of the Change

After giving a alias config some users who's alias names didn't match their gitUsernames were not shown in the data. 

---

## Implementation Details

The call for getFilteredData inside getAnalyticsData was given a userId allowing its call to applyAliasMappingIfNeeded to actually obtain a correct mappedRepo.

---

## Steps to Test (if applicable)

1. Enter test repo
2. Login/Sign up and use the alias config file [new-alias-config.json](https://github.com/user-attachments/files/23019222/new-alias-config.json)
3. Go to metrics page to see if all the contributors are shown with their proper alias

---



## Screenshots (if applicable)

<img width="2704" height="1512" alt="screenshot-2025-10-21-21-43-04" src="https://github.com/user-attachments/assets/9a3805c6-0e8d-48eb-824f-4560933095aa" />

---

## Linked Issue/Story

https://app.clickup.com/t/86d0pc69r
