### PR TITLE
Fix/generate scaling popup

### DIFF
--- a/commitment/imports/ui/components/scaling/ScalingConfigForm.tsx
+++ b/commitment/imports/ui/components/scaling/ScalingConfigForm.tsx
@@ -87,7 +87,7 @@ function ScalingConfigForm({ onSubmit }: ScalingConfigFormProps) {
         const result = (await Meteor.callAsync(
           "isSmallContributorGroup",
           repoUrl,
-          11
+          7
         )) as boolean;
 
         // Save the result in the cache


### PR DESCRIPTION
# Reducing Meteor Calls in Generate Scaling Popup

## High-Level Description
A fix was made to the Generate Scaling Popup where only one meteor call is required upon opening and further openings rely on data stored persistently.

_Provide a short summary of the change._
Removed the useState and turned it into a normal constant outside of the ScalingConfigForm function.

---

## Purpose of the Change

_Why was this change made? What problem or requirement does it address?_
The change was made to address the waiting of scaling methods on every opening of the Generate Scaling Popup, which makes the system inconvenient to use.

---

## Implementation Details
- Only changed ScalingConfigForm
- Updated state variables to be accessed globally to the function


_Describe how the change was implemented, including any key design decisions or architectural considerations._
- The main design decision was to put the state variable outside of the function. This meant that if it was populated with data, then it would be used instead of doing a meteor call.
---

## Steps to Test (if applicable)
1. Use Amy Test Repo and navigate to the Scaling Page. The popup should show up automatically. At this stage, take note of how long it takes the methods to generate. Previously this was faster, but due to changes in other parts of the system, these fetches have become slower.
2. After the scaling methods have rendered, exit the popup and click Create Scaling. The methods should show up much faster now.
3. Exit the popup and go to the metrics page. Return back to scaling and validate that the methods show up almost instantly.

---

## Screenshots (if applicable)

N/A - just look at the scaling page

---

## Linked Issue/Story

https://app.clickup.com/t/86d09vknw
