### PR TITLE
change format of CSV export so emails are a list

### DIFF
--- a/commitment/imports/ui/components/scaling/CustomScriptExport/exportDataService.ts
+++ b/commitment/imports/ui/components/scaling/CustomScriptExport/exportDataService.ts
@@ -200,7 +200,7 @@ export class ExportDataService {
         
         // Include all emails from aliases if available
         const allEmails = [...new Set(contributorEmails)];
-        const emailsString = allEmails.length > 0 ? allEmails.join(', ') : '';
+        const emailsString = allEmails.length > 0 ? allEmails.join('; ') : '';
         
         // Contributor info (match header order: contributor_name, contributor_email)
         row.push(contributorName);


### PR DESCRIPTION
# Pull Request Title
## High-Level Description

change the delimter of the email list so that they are not seperated into coloumns

---

## Purpose of the Change

the python script executor needs email as a string 

---

## Implementation Details

change the delimiter
---

## Steps to Test (if applicable)

download file to see if emails are not seperated

---

## Screenshots (if applicable)

_Include any relevant screenshots or visual diffs here, reference them where required._

---

## Linked Issue/Story

_Link to the relevant ClickUp task or issue. Example: [CU-abc123](https://app.clickup.com/t/abc123)_
