### PR TITLE
fix: allow nested literals to appear in string for custom script output

### DIFF
--- a/python_executor/executor/python_executor.py
+++ b/python_executor/executor/python_executor.py
@@ -11,7 +11,7 @@ import re
 PORT = 8002
 app = Flask(__name__)
 
-ALLOWED_LITERAL_PATTERN = r'\[([^\(\[\{\)\]\}]|(\"[^\"]\")|(\'[^\']\'))*\]'
+ALLOWED_LITERAL_PATTERN = r'\[([^\(\[\{\)\]\}]|(\"[^\"]*\")|(\'[^\']*\'))*\]'
 ALLOWED_LITERAL_RE = re.compile(ALLOWED_LITERAL_PATTERN)
 
 


### PR DESCRIPTION
…r.py script output

# Allow nested literals to appear in string for custom script output

This updates the python_executor allowed output regex to be more permissive

---

## Purpose of the Change

I tested using our repo for this, and it broke because someone had parentheses () in their name.

---

## Implementation Details

I Just permit anything between two quotation marks

---

## Steps to Test (if applicable)

open up our repo and try run python scaling on it.

---

## Screenshots (if applicable)

previous:
<img width="1074" height="204" alt="image" src="https://github.com/user-attachments/assets/c1ebea8c-fcb9-4a67-8624-0e39bdfa01d6" />


