### PR TITLE
fix: python_executor Dockerfile on Windows

### DIFF
--- a/python_executor/Dockerfile
+++ b/python_executor/Dockerfile
@@ -4,12 +4,15 @@
 FROM nixos/nix
 
 # Add dependencies to the environment
-RUN nix-env -iA nixpkgs.bash
+RUN nix-env -iA nixpkgs.bash nixpkgs.dos2unix
 
 WORKDIR /home/python
 
 # Copy application files
 COPY . .
+
+# Remove CRLF
+RUN find . -type f -exec dos2unix {} +
 
 # Build the nix project
 RUN nix-build


### PR DESCRIPTION
# Pull Request Title
## High-Level Description

If you had any CRLF file endings on windows, nix would explode, and python_executor wouldn't build.

---

## Purpose of the Change

We want people on windows to be able to build and run the app

---

## Implementation Details

This adds a utility to automatically convert all files to LF line endings before running nix-build

---

## Steps to Test (if applicable)

Turn on Windows computer. Build the docker compose file.
