### PR TITLE
fix: python executor containers in prod

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -36,6 +36,7 @@ services:
     container_name: python-executor
     security_opt:
       - seccomp:./python_executor/seccomp-bwrap.json
+      - apparmor=unconfined
     tty: true
     stdin_open: true
     ports:


### PR DESCRIPTION
## High-Level Description

This allows the python executor to create linux namespaces

---

## Purpose of the Change

Prod environment had different restrictions than previous environments we've tested with, and we needed to specify that explicitly

---

## Steps to Test (if applicable)

I have already tested this with the production server
